### PR TITLE
fix: add --allow-dirty to cargo publish in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           cargo update --workspace
 
       - name: Publish lineark-sdk
-        run: cargo publish -p lineark-sdk --no-verify
+        run: cargo publish -p lineark-sdk --no-verify --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -50,7 +50,7 @@ jobs:
           echo "Timed out waiting for indexing, proceeding anyway"
 
       - name: Publish lineark
-        run: cargo publish -p lineark --no-verify
+        run: cargo publish -p lineark --no-verify --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
The sed version patching (0.0.0 → tag version) creates uncommitted changes in Cargo.toml, which `cargo publish` rejects by default. Adding `--allow-dirty` since the dirty state is intentional.

This is safe because we already use `--no-verify` (skipping local build), and the version patching is the *only* source of dirtiness.