### PR TITLE
fix: post-Phase 3 review — 30 bugs, edge cases, and docs fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "home",
  "libtest-with",
  "lineark-sdk",
+ "percent-encoding",
  "predicates",
  "serde",
  "serde_json",
@@ -891,6 +892,7 @@ dependencies = [
  "tempfile",
  "test-with",
  "tokio",
+ "url",
  "uuid",
  "wiremock",
 ]

--- a/README.md
+++ b/README.md
@@ -58,14 +58,40 @@ lineark teams list                               List all teams
 lineark users list [--active]                    List users
 lineark projects list                            List all projects
 lineark labels list                              List issue labels
-lineark cycles list [--limit N]                  List cycles
-lineark cycles read <ID>                         Read a specific cycle
+lineark cycles list [--limit N] [--team KEY]     List cycles
+  [--active]                                     Only the active cycle
+  [--around-active N]                            Active ± N neighbors
+lineark cycles read <ID> [--team KEY]            Read cycle (UUID, name, or number)
 lineark issues list [--limit N] [--team KEY]     Active issues, newest first
   [--mine]                                       Only issues assigned to me
   [--show-done]                                  Include done/canceled issues
 lineark issues read <IDENTIFIER>                 Full issue detail (e.g., E-929)
 lineark issues search <QUERY> [--limit N]        Full-text search
   [--show-done]                                  Include done/canceled results
+lineark issues create <TITLE> --team KEY         Create an issue
+  [--priority 0-4] [--assignee ID]               0=none 1=urgent 2=high 3=medium 4=low
+  [--labels ID,...] [--description TEXT]          Comma-separated label UUIDs
+  [--status NAME] [--parent ID]                  Status resolved against team states
+lineark issues update <IDENTIFIER>               Update an issue
+  [--status NAME] [--priority 0-4]               Status resolved against team states
+  [--assignee ID] [--parent ID]                  User UUID or issue identifier
+  [--labels ID,...] [--label-by adding|replacing|removing]
+  [--clear-labels] [--title TEXT] [--description TEXT]
+lineark issues archive <IDENTIFIER>              Archive an issue
+lineark issues unarchive <IDENTIFIER>            Unarchive a previously archived issue
+lineark issues delete <IDENTIFIER>               Delete (trash) an issue
+  [--permanently]                                Permanently delete instead of trashing
+lineark comments create <ISSUE-ID> --body TEXT   Comment on an issue
+lineark documents list [--limit N]               List documents
+lineark documents read <ID>                      Read document (includes content)
+lineark documents create --title TEXT             Create a document
+  [--content TEXT] [--project ID] [--issue ID]
+lineark documents update <ID>                    Update a document
+  [--title TEXT] [--content TEXT]
+lineark documents delete <ID>                    Delete (trash) a document
+lineark embeds upload <FILE> [--public]          Upload file, returns asset URL
+lineark embeds download <URL>                    Download a file by URL
+  [--output PATH] [--overwrite]
 lineark usage                                    Compact command reference
 ```
 

--- a/crates/lineark-codegen/src/emit_mutations.rs
+++ b/crates/lineark-codegen/src/emit_mutations.rs
@@ -119,7 +119,8 @@ fn build_payload_selection(
         match type_kind_map.get(base) {
             Some(TypeKind::Scalar) | Some(TypeKind::Enum) => {
                 // Include scalar/enum fields directly (e.g., lastSyncId)
-                if field.name != "lastSyncId" {
+                // Skip `success` (already hardcoded above) and `lastSyncId` (internal)
+                if field.name != "lastSyncId" && field.name != "success" {
                     parts.push(field.name.clone());
                 }
             }

--- a/crates/lineark-sdk/Cargo.toml
+++ b/crates/lineark-sdk/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 home = "0.5"
+url = "2"
 
 [dev-dependencies]
 wiremock = "0.6"
@@ -35,4 +36,4 @@ required-features = ["blocking"]
 
 [features]
 default = []
-blocking = ["reqwest/blocking"]
+blocking = []

--- a/crates/lineark-sdk/README.md
+++ b/crates/lineark-sdk/README.md
@@ -174,6 +174,9 @@ All methods return `Result<T, LinearError>`. Error variants:
 - `GraphQL` — errors returned in the GraphQL response
 - `Network` — connection/transport failures
 - `HttpError` — non-200 responses not covered above
+- `MissingData` — expected data path not found in response
+- `AuthConfig` — auth configuration error (no token found)
+- `Internal` — internal error (e.g. runtime creation failure)
 
 ## Codegen
 

--- a/crates/lineark-sdk/src/error.rs
+++ b/crates/lineark-sdk/src/error.rs
@@ -33,6 +33,8 @@ pub enum LinearError {
     HttpError { status: u16, body: String },
     /// Auth configuration error (no token found).
     AuthConfig(String),
+    /// Internal error (e.g. runtime creation failure).
+    Internal(String),
 }
 
 impl fmt::Display for LinearError {
@@ -61,6 +63,7 @@ impl fmt::Display for LinearError {
             }
             Self::MissingData(path) => write!(f, "Missing data at path: {}", path),
             Self::AuthConfig(msg) => write!(f, "Auth configuration error: {}", msg),
+            Self::Internal(msg) => write!(f, "Internal error: {}", msg),
         }
     }
 }
@@ -206,6 +209,15 @@ mod tests {
     fn linear_error_is_std_error() {
         let err = LinearError::Authentication("test".to_string());
         let _: &dyn std::error::Error = &err;
+    }
+
+    #[test]
+    fn display_internal_error() {
+        let err = LinearError::Internal("Failed to create tokio runtime: foo".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Internal error: Failed to create tokio runtime: foo"
+        );
     }
 
     #[test]

--- a/crates/lineark-sdk/src/generated/mutations.rs
+++ b/crates/lineark-sdk/src/generated/mutations.rs
@@ -21,7 +21,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation FileUpload($metaData: JSON, $makePublic: Boolean, $size: Int!, $contentType: String!, $filename: String!) { fileUpload(metaData: $metaData, makePublic: $makePublic, size: $size, contentType: $contentType, filename: $filename) { success uploadFile { filename contentType size uploadUrl assetUrl metaData } success } }",
+                "mutation FileUpload($metaData: JSON, $makePublic: Boolean, $size: Int!, $contentType: String!, $filename: String!) { fileUpload(metaData: $metaData, makePublic: $makePublic, size: $size, contentType: $contentType, filename: $filename) { success uploadFile { filename contentType size uploadUrl assetUrl metaData } } }",
                 variables,
                 "fileUpload",
             )
@@ -35,7 +35,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation ImageUploadFromUrl($url: String!) { imageUploadFromUrl(url: $url) { success url success } }",
+                "mutation ImageUploadFromUrl($url: String!) { imageUploadFromUrl(url: $url) { success url } }",
                 variables,
                 "imageUploadFromUrl",
             )
@@ -49,7 +49,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation CommentCreate($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id createdAt updatedAt archivedAt body issueId documentContentId projectUpdateId initiativeUpdateId parentId resolvedAt resolvingCommentId editedAt bodyData quotedText reactionData threadSummary isArtificialAgentSessionRoot url hideInLinear } success } }",
+                "mutation CommentCreate($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id createdAt updatedAt archivedAt body issueId documentContentId projectUpdateId initiativeUpdateId parentId resolvedAt resolvingCommentId editedAt bodyData quotedText reactionData threadSummary isArtificialAgentSessionRoot url hideInLinear } } }",
                 variables,
                 "commentCreate",
             )
@@ -63,7 +63,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueCreate($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } success } }",
+                "mutation IssueCreate($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
                 variables,
                 "issueCreate",
             )
@@ -78,7 +78,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueUpdate($input: IssueUpdateInput!, $id: String!) { issueUpdate(input: $input, id: $id) { success issue { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } success } }",
+                "mutation IssueUpdate($input: IssueUpdateInput!, $id: String!) { issueUpdate(input: $input, id: $id) { success issue { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
                 variables,
                 "issueUpdate",
             )
@@ -93,7 +93,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueArchive($trash: Boolean, $id: String!) { issueArchive(trash: $trash, id: $id) { success success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
+                "mutation IssueArchive($trash: Boolean, $id: String!) { issueArchive(trash: $trash, id: $id) { success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
                 variables,
                 "issueArchive",
             )
@@ -104,7 +104,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueUnarchive($id: String!) { issueUnarchive(id: $id) { success success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
+                "mutation IssueUnarchive($id: String!) { issueUnarchive(id: $id) { success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
                 variables,
                 "issueUnarchive",
             )
@@ -121,7 +121,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueDelete($permanentlyDelete: Boolean, $id: String!) { issueDelete(permanentlyDelete: $permanentlyDelete, id: $id) { success success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
+                "mutation IssueDelete($permanentlyDelete: Boolean, $id: String!) { issueDelete(permanentlyDelete: $permanentlyDelete, id: $id) { success entity { id createdAt updatedAt archivedAt number title priority estimate boardOrder sortOrder prioritySortOrder startedAt completedAt startedTriageAt triagedAt canceledAt autoClosedAt autoArchivedAt dueDate slaStartedAt slaMediumRiskAt slaHighRiskAt slaBreachesAt slaType addedToProjectAt addedToCycleAt addedToTeamAt trashed snoozedUntilAt suggestionsGeneratedAt activitySummary labelIds previousIdentifiers subIssueSortOrder reactionData priorityLabel integrationSourceType identifier url branchName customerTicketCount description } } }",
                 variables,
                 "issueDelete",
             )
@@ -138,7 +138,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation IssueRelationCreate($overrideCreatedAt: DateTime, $input: IssueRelationCreateInput!) { issueRelationCreate(overrideCreatedAt: $overrideCreatedAt, input: $input) { success issueRelation { id createdAt updatedAt archivedAt type } success } }",
+                "mutation IssueRelationCreate($overrideCreatedAt: DateTime, $input: IssueRelationCreateInput!) { issueRelationCreate(overrideCreatedAt: $overrideCreatedAt, input: $input) { success issueRelation { id createdAt updatedAt archivedAt type } } }",
                 variables,
                 "issueRelationCreate",
             )
@@ -152,7 +152,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation DocumentCreate($input: DocumentCreateInput!) { documentCreate(input: $input) { success document { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } success } }",
+                "mutation DocumentCreate($input: DocumentCreateInput!) { documentCreate(input: $input) { success document { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } } }",
                 variables,
                 "documentCreate",
             )
@@ -167,7 +167,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation DocumentUpdate($input: DocumentUpdateInput!, $id: String!) { documentUpdate(input: $input, id: $id) { success document { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } success } }",
+                "mutation DocumentUpdate($input: DocumentUpdateInput!, $id: String!) { documentUpdate(input: $input, id: $id) { success document { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } } }",
                 variables,
                 "documentUpdate",
             )
@@ -178,7 +178,7 @@ impl Client {
         self.execute::<
                 serde_json::Value,
             >(
-                "mutation DocumentDelete($id: String!) { documentDelete(id: $id) { success success entity { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } } }",
+                "mutation DocumentDelete($id: String!) { documentDelete(id: $id) { success entity { id createdAt updatedAt archivedAt title icon color slugId hiddenAt trashed sortOrder content contentState documentContentId url } } }",
                 variables,
                 "documentDelete",
             )

--- a/crates/lineark/Cargo.toml
+++ b/crates/lineark/Cargo.toml
@@ -11,13 +11,14 @@ readme = "README.md"
 [dependencies]
 lineark-sdk = { path = "../lineark-sdk", version = "0.0.0" }
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 serde_json = "1"
 tabled = "0.17"
 colored = "2"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 uuid = "1"
+percent-encoding = "2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/lineark/src/commands/comments.rs
+++ b/crates/lineark/src/commands/comments.rs
@@ -2,6 +2,7 @@ use clap::Args;
 use lineark_sdk::generated::inputs::CommentCreateInput;
 use lineark_sdk::Client;
 
+use super::helpers::{check_success, resolve_issue_id};
 use crate::output::{self, Format};
 
 /// Manage comments.
@@ -44,42 +45,11 @@ pub async fn run(cmd: CommentsCmd, client: &Client, format: Format) -> anyhow::R
                 .await
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-            if payload.get("success").and_then(|v| v.as_bool()) != Some(true) {
-                return Err(anyhow::anyhow!(
-                    "Comment creation failed: {}",
-                    serde_json::to_string_pretty(&payload).unwrap_or_default()
-                ));
-            }
+            check_success(&payload)?;
 
             let comment = payload.get("comment").cloned().unwrap_or_default();
             output::print_one(&comment, format);
         }
     }
     Ok(())
-}
-
-/// Resolve an issue identifier (e.g., ENG-123) to a UUID.
-async fn resolve_issue_id(client: &Client, identifier: &str) -> anyhow::Result<String> {
-    if uuid::Uuid::parse_str(identifier).is_ok() {
-        return Ok(identifier.to_string());
-    }
-    let variables = serde_json::json!({ "term": identifier, "first": 5 });
-    let conn: lineark_sdk::Connection<serde_json::Value> = client
-        .execute_connection(
-            "query IssueIdSearch($term: String!, $first: Int) { searchIssues(term: $term, first: $first) { nodes { id identifier } pageInfo { hasNextPage endCursor } } }",
-            variables,
-            "searchIssues",
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    conn.nodes
-        .iter()
-        .find(|n| {
-            n.get("identifier")
-                .and_then(|v| v.as_str())
-                .is_some_and(|id| id.eq_ignore_ascii_case(identifier))
-        })
-        .and_then(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
-        .ok_or_else(|| anyhow::anyhow!("Issue '{}' not found", identifier))
 }

--- a/crates/lineark/src/commands/helpers.rs
+++ b/crates/lineark/src/commands/helpers.rs
@@ -1,0 +1,78 @@
+use lineark_sdk::Client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NestedUser {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NestedProject {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Resolve a team key (e.g., "ENG") to a team UUID.
+/// If the input already looks like a UUID, return it as-is.
+pub async fn resolve_team_id(client: &Client, team_key: &str) -> anyhow::Result<String> {
+    if uuid::Uuid::parse_str(team_key).is_ok() {
+        return Ok(team_key.to_string());
+    }
+    let conn = client
+        .teams()
+        .first(250)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    for team in &conn.nodes {
+        if team
+            .key
+            .as_deref()
+            .is_some_and(|k| k.eq_ignore_ascii_case(team_key))
+        {
+            return Ok(team.id.clone().unwrap_or_default());
+        }
+    }
+    Err(anyhow::anyhow!("Team '{}' not found", team_key))
+}
+
+/// Resolve an issue identifier (e.g., ENG-123) to a UUID.
+/// If the input already looks like a UUID, return it as-is.
+pub async fn resolve_issue_id(client: &Client, identifier: &str) -> anyhow::Result<String> {
+    if uuid::Uuid::parse_str(identifier).is_ok() {
+        return Ok(identifier.to_string());
+    }
+    let variables = serde_json::json!({ "term": identifier, "first": 5 });
+    let conn: lineark_sdk::Connection<serde_json::Value> = client
+        .execute_connection(
+            "query IssueIdResolve($term: String!, $first: Int) { searchIssues(term: $term, first: $first) { nodes { id identifier } pageInfo { hasNextPage endCursor } } }",
+            variables,
+            "searchIssues",
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    conn.nodes
+        .iter()
+        .find(|n| {
+            n.get("identifier")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id.eq_ignore_ascii_case(identifier))
+        })
+        .and_then(|n| n.get("id").and_then(|v| v.as_str()).map(String::from))
+        .ok_or_else(|| anyhow::anyhow!("Issue '{}' not found", identifier))
+}
+
+/// Check the `success` field in a mutation payload.
+pub fn check_success(payload: &serde_json::Value) -> anyhow::Result<()> {
+    if payload.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(anyhow::anyhow!(
+            "Operation failed: {}",
+            serde_json::to_string_pretty(payload).unwrap_or_default()
+        ));
+    }
+    Ok(())
+}

--- a/crates/lineark/src/commands/mod.rs
+++ b/crates/lineark/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod comments;
 pub mod cycles;
 pub mod documents;
 pub mod embeds;
+pub mod helpers;
 pub mod issues;
 pub mod labels;
 pub mod projects;

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -42,7 +42,7 @@ COMMANDS:
     [--assignee ID] [--parent ID]                  User UUID or issue identifier
     [--labels ID,...] [--label-by adding|replacing|removing]
     [--clear-labels] [--title TEXT] [--description TEXT]
-  lineark issues archive <IDENTIFIER>               Archive an issue
+  lineark issues archive <IDENTIFIER>              Archive an issue
   lineark issues unarchive <IDENTIFIER>            Unarchive a previously archived issue
   lineark issues delete <IDENTIFIER>               Delete (trash) an issue
     [--permanently]                                Permanently delete instead of trashing

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -24,10 +24,12 @@ issueRelation = true
 # Phase 2 — Core writes
 issueCreate = true
 issueUpdate = true
+commentCreate = true
+
+# Phase 3 — Issue lifecycle
 issueArchive = true
 issueUnarchive = true
 issueDelete = true
-commentCreate = true
 
 # Phase 3 — Rich features
 documentCreate = true


### PR DESCRIPTION
Closes #53

## Summary

Addresses all 30 issues from the post-Phase 3 staff-architect-level review (#53).

### HIGH PRIORITY (1-6)
- **BlockingQuery unsound unsafe Send** — replaced raw pointer with lifetime reference, eliminating all `unsafe` code
- **download_url token leak** — only sends `Authorization` header to `*.linear.app` URLs
- **documents create --issue** — now resolves identifiers (e.g. `ENG-123`) to UUIDs before sending to API
- **--active/--around-active conflict** — added `conflicts_with` so clap rejects both at once
- **Empty LINEAR_API_TOKEN** — empty/whitespace-only env var now falls through to file-based auth
- **Cycle number f64 parsing** — changed to i64, rejecting `NaN`/`inf` inputs

### MEDIUM PRIORITY (7-14)
- **embeds upload memory** — capture file size before move instead of cloning bytes
- **Empty filename fallback** — URLs ending in `/` now produce `"download"` filename
- **No-op mutation validation** — `issues update` and `documents update` with no flags now error early
- **Duplicate success field** — fixed codegen to not emit `success` twice in mutations
- **Unused reqwest/blocking** — blocking feature no longer pulls in `reqwest::blocking`
- **Runtime error variant** — added `LinearError::Internal`, fixed misclassification as `AuthConfig`
- **--around-active no active cycle** — returns empty vec + warning instead of all cycles
- **resolve_team_id pagination** — added `.first(250)` to both copies (now deduplicated)

### LOW PRIORITY (15-20)
- **Shared helpers module** — extracted `resolve_team_id`, `resolve_issue_id`, `check_success`, `NestedUser`, `NestedProject` into `commands/helpers.rs`
- **usage.rs alignment** — fixed column spacing for archive/unarchive
- **blocking::Client Debug** — added manual `Debug` impl
- **Async file I/O** — embeds now uses `tokio::fs` instead of `std::fs`
- **URL-decoded filenames** — percent-encoded chars in download filenames are now decoded

### DOCS (21-30)
- **README.md** — added all Phase 2/3 commands to usage block
- **MASTERPLAN.md** — fixed command structure, code examples, API shapes, dependency listings, file tree, target list, self-referential sentence, operations.toml sample
- **SDK README** — added missing error variants (`MissingData`, `AuthConfig`, `Internal`)
- **operations.toml** — fixed phase labels for `issueUnarchive`/`issueDelete`

## Test plan

- [x] All existing tests pass (192 tests across SDK, CLI, codegen)
- [x] New tests added for:
  - Empty/whitespace `LINEAR_API_TOKEN` handling (3 tests)
  - `download_url` auth behavior for non-Linear URLs
  - `Internal` error variant display
  - `--active`/`--around-active` conflict rejection
  - No-op update validation for issues and documents
  - Cycle number parsing rejects NaN/inf
- [x] `make check` passes (fmt, clippy, build, test)
- [x] Codegen regenerated — verified no duplicate `success` fields