### PR TITLE
fix: users list shows displayName as name, losing actual full name

### DIFF
--- a/crates/lineark/src/commands/users.rs
+++ b/crates/lineark/src/commands/users.rs
@@ -24,9 +24,11 @@ pub enum UsersAction {
 }
 
 #[derive(Debug, Serialize, Tabled)]
+#[serde(rename_all = "camelCase")]
 pub struct UserRow {
     pub id: String,
     pub name: String,
+    pub display_name: String,
     pub email: String,
     pub active: bool,
 }
@@ -47,7 +49,8 @@ pub async fn run(cmd: UsersCmd, client: &Client, format: Format) -> anyhow::Resu
                 .filter(|u| !active || u.active.unwrap_or(false))
                 .map(|u| UserRow {
                     id: u.id.clone().unwrap_or_default(),
-                    name: u.display_name.clone().unwrap_or_default(),
+                    name: u.name.clone().unwrap_or_default(),
+                    display_name: u.display_name.clone().unwrap_or_default(),
                     email: u.email.clone().unwrap_or_default(),
                     active: u.active.unwrap_or(false),
                 })

--- a/crates/lineark/src/commands/viewer.rs
+++ b/crates/lineark/src/commands/viewer.rs
@@ -10,7 +10,8 @@ use crate::output::{self, Format};
 #[serde(rename_all = "camelCase", default)]
 pub struct ViewerRow {
     pub id: String,
-    #[tabled(rename = "name")]
+    pub name: String,
+    #[tabled(rename = "displayName")]
     pub display_name: String,
     pub email: String,
     pub active: bool,
@@ -40,6 +41,6 @@ pub async fn run(client: &Client, format: Format) -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    output::print_table(&[viewer], format);
+    output::print_one(&viewer, format);
     Ok(())
 }

--- a/crates/lineark/tests/cli_online.rs
+++ b/crates/lineark/tests/cli_online.rs
@@ -58,13 +58,9 @@ mod cli_online {
         assert!(output.status.success(), "whoami should succeed");
         let json: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
-        let arr = json.as_array().expect("whoami JSON should be an array");
-        assert!(!arr.is_empty(), "whoami array should not be empty");
-        assert!(arr[0].get("id").is_some(), "whoami entry should contain id");
-        assert!(
-            arr[0].get("email").is_some(),
-            "whoami entry should contain email"
-        );
+        assert!(json.is_object(), "whoami JSON should be an object");
+        assert!(json.get("id").is_some(), "whoami should contain id");
+        assert!(json.get("email").is_some(), "whoami should contain email");
     }
 
     #[test_with::runtime_ignore_if(no_online_test_token)]


### PR DESCRIPTION
## Summary

- `users list` was mapping `displayName` into the `name` column, so the user's real full name was lost
- Added `displayName` as a separate field in both `users list` and `whoami` output
- `name` now correctly shows the user's full name (e.g. "Carlos Eduardo" instead of "cadu.coelho")
- `whoami` now outputs a single JSON object instead of a 1-element array, since it always returns exactly one user

Closes #69

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all 243 tests pass
- [x] `cargo fmt --check` — clean
- [x] Verified `whoami` JSON output is a single object with both `name` and `displayName`