### PR TITLE
feat: `lineark self update` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           sed -i'' -e "s/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"0.0.0\" }/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"${VERSION}\" }/" crates/lineark/Cargo.toml
 
       - name: Build binary
-        run: cargo build --release --target ${{ matrix.target }} -p lineark
+        run: cargo build --release --target ${{ matrix.target }} -p lineark --features binary-release
         env:
           RUSTFLAGS: -Dwarnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ dependencies = [
  "lineark-sdk",
  "percent-encoding",
  "predicates",
+ "reqwest",
  "serde",
  "serde_json",
  "tabled",

--- a/crates/lineark/Cargo.toml
+++ b/crates/lineark/Cargo.toml
@@ -8,10 +8,15 @@ authors.workspace = true
 description = "CLI for Linear issue tracker — for humans and LLMs"
 readme = "README.md"
 
+[features]
+default = []
+binary-release = []
+
 [dependencies]
 lineark-sdk = { path = "../lineark-sdk", version = "0.0.0" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 tabled = "0.17"
 colored = "2"
@@ -20,6 +25,7 @@ chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
 uuid = "1"
 percent-encoding = "2"
+home = "0.5"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/lineark/src/commands/mod.rs
+++ b/crates/lineark/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod issues;
 pub mod labels;
 pub mod milestones;
 pub mod projects;
+pub mod self_cmd;
 pub mod teams;
 pub mod usage;
 pub mod users;

--- a/crates/lineark/src/commands/self_cmd.rs
+++ b/crates/lineark/src/commands/self_cmd.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+
+use crate::version_check;
+
+#[derive(Debug, Parser)]
+pub struct SelfCmd {
+    #[command(subcommand)]
+    pub action: SelfAction,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SelfAction {
+    /// Update lineark to the latest release.
+    Update(UpdateArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct UpdateArgs {
+    /// Just check if an update is available, don't install it.
+    #[arg(long)]
+    check: bool,
+}
+
+pub async fn run(cmd: SelfCmd) -> Result<()> {
+    match cmd.action {
+        SelfAction::Update(args) => run_update(args).await,
+    }
+}
+
+async fn run_update(args: UpdateArgs) -> Result<()> {
+    if version_check::is_dev_build() {
+        eprintln!("Running a dev build (0.0.0) — self-update is not supported.");
+        return Ok(());
+    }
+
+    let current = version_check::current_version();
+    let latest = version_check::get_latest_version(true)
+        .await
+        .context("could not determine the latest version")?;
+
+    if args.check {
+        if current == latest {
+            println!("lineark {} is already the latest version.", current.green());
+        } else {
+            println!(
+                "Update available: {} → {}",
+                current.yellow(),
+                latest.green()
+            );
+            println!("Run `lineark self update` to upgrade.");
+        }
+        return Ok(());
+    }
+
+    if current == latest {
+        println!("lineark {} is already the latest version.", current.green());
+        return Ok(());
+    }
+
+    println!("Updating lineark {} → {}", current.yellow(), latest.green());
+
+    if cfg!(feature = "binary-release") {
+        update_binary(&latest).await
+    } else {
+        update_cargo().await
+    }
+}
+
+/// Binary mode: download the release asset and replace the current executable.
+async fn update_binary(version: &str) -> Result<()> {
+    let url = version_check::release_asset_url(version)?;
+    let current_exe =
+        std::env::current_exe().context("could not determine current executable path")?;
+
+    println!("Downloading from GitHub Releases...");
+
+    let client = reqwest::Client::new();
+    let bytes = client
+        .get(&url)
+        .header("User-Agent", "lineark-self-update")
+        .send()
+        .await
+        .context("failed to download release binary")?
+        .error_for_status()
+        .context("download failed")?
+        .bytes()
+        .await
+        .context("failed to read response body")?;
+
+    // Write to a temp file next to the current binary, then rename atomically.
+    let tmp_path = current_exe.with_extension("tmp-update");
+    tokio::fs::write(&tmp_path, &bytes)
+        .await
+        .context("failed to write temporary file")?;
+
+    // Set executable bit (unix only).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        tokio::fs::set_permissions(&tmp_path, perms)
+            .await
+            .context("failed to set executable permissions")?;
+    }
+
+    tokio::fs::rename(&tmp_path, &current_exe)
+        .await
+        .context("failed to replace binary — you may need to run with appropriate permissions")?;
+
+    println!(
+        "lineark {} installed to {}",
+        version.green(),
+        current_exe.display()
+    );
+    Ok(())
+}
+
+/// Cargo mode: shell out to `cargo install lineark`.
+async fn update_cargo() -> Result<()> {
+    // Verify cargo is available.
+    let cargo_check = std::process::Command::new("cargo")
+        .arg("--version")
+        .output();
+    if cargo_check.is_err() || !cargo_check.unwrap().status.success() {
+        anyhow::bail!(
+            "lineark was installed via cargo, but `cargo` is not in your PATH.\n\
+             Install Rust from https://rustup.rs or add cargo to your PATH."
+        );
+    }
+
+    println!("Running `cargo install lineark`...");
+
+    let status = std::process::Command::new("cargo")
+        .args(["install", "lineark"])
+        .status()
+        .context("failed to run `cargo install lineark`")?;
+
+    if !status.success() {
+        anyhow::bail!("`cargo install lineark` exited with status {}", status);
+    }
+
+    println!("{}", "Update complete.".green());
+    Ok(())
+}

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -1,5 +1,7 @@
+use crate::version_check;
+
 /// Print a compact LLM-friendly command reference (<1000 tokens).
-pub fn run() {
+pub async fn run() {
     let env_hint = if std::env::var("LINEAR_API_TOKEN").is_ok() {
         " (set)"
     } else {
@@ -80,6 +82,8 @@ COMMANDS:
                                                    --public only works for images (not SVG)
   lineark embeds download <URL>                    Download any file by URL (works with
     [--output PATH] [--overwrite]                  Linear CDN URLs and external URLs alike)
+  lineark self update                              Update lineark to the latest release
+  lineark self update --check                      Check if an update is available
 
 GLOBAL OPTIONS:
   --api-token <TOKEN>   Override API token
@@ -91,4 +95,13 @@ AUTH (in precedence order):
   3. ~/.linear_api_token file{file_hint}
 "#
     );
+
+    // Show update hint (uses cache, goes online at most once per 24h).
+    if !version_check::is_dev_build() {
+        let latest = version_check::get_latest_version(false).await;
+        let hint = crate::format_update_hint(latest.as_deref());
+        if !hint.is_empty() {
+            print!("{hint}");
+        }
+    }
 }

--- a/crates/lineark/src/main.rs
+++ b/crates/lineark/src/main.rs
@@ -1,12 +1,13 @@
 mod commands;
 mod output;
+mod version_check;
 
 use clap::{Parser, Subcommand};
 use lineark_sdk::Client;
 
 /// lineark — Linear CLI for humans and LLMs
 #[derive(Debug, Parser)]
-#[command(name = "lineark", version, about)]
+#[command(name = "lineark", version, about, after_help = update_hint_blocking())]
 struct Cli {
     /// API token (overrides $LINEAR_API_TOKEN and ~/.linear_api_token).
     #[arg(long, global = true)]
@@ -46,6 +47,38 @@ enum Command {
     Embeds(commands::embeds::EmbedsCmd),
     /// Print a compact LLM-friendly command reference.
     Usage,
+    /// Manage lineark itself (update, etc.).
+    #[command(name = "self")]
+    SelfCmd(commands::self_cmd::SelfCmd),
+}
+
+/// Build an update hint string using a blocking one-shot tokio runtime for use in clap's
+/// `after_help` (which requires a plain string at parse time). Uses the cached version check
+/// (no network call unless cache is stale/missing).
+fn update_hint_blocking() -> String {
+    if version_check::is_dev_build() {
+        return String::new();
+    }
+    // Use a lightweight current-thread runtime so we don't conflict with the main runtime.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build();
+    let latest = match rt {
+        Ok(rt) => rt.block_on(version_check::get_latest_version(false)),
+        Err(_) => None,
+    };
+    format_update_hint(latest.as_deref())
+}
+
+/// Format the update hint string. Shared by --help and usage.
+pub fn format_update_hint(latest: Option<&str>) -> String {
+    let current = version_check::current_version();
+    match latest {
+        Some(v) if v != current => {
+            format!("\nUpdate available: {current} → {v}\nRun `lineark self update` to upgrade.\n")
+        }
+        _ => String::new(),
+    }
 }
 
 #[tokio::main]
@@ -53,10 +86,20 @@ async fn main() {
     let cli = Cli::parse();
     let format = output::resolve_format(cli.format);
 
-    // Handle usage command before auth (it doesn't need a client).
-    if matches!(cli.command, Command::Usage) {
-        commands::usage::run();
-        return;
+    // Handle commands that don't need auth.
+    match cli.command {
+        Command::Usage => {
+            commands::usage::run().await;
+            return;
+        }
+        Command::SelfCmd(cmd) => {
+            if let Err(e) = commands::self_cmd::run(cmd).await {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+            return;
+        }
+        _ => {}
     }
 
     // Resolve client.
@@ -84,7 +127,7 @@ async fn main() {
         Command::Documents(cmd) => commands::documents::run(cmd, &client, format).await,
         Command::Embeds(cmd) => commands::embeds::run(cmd, &client, format).await,
         Command::ProjectMilestones(cmd) => commands::milestones::run(cmd, &client, format).await,
-        Command::Usage => unreachable!(),
+        Command::Usage | Command::SelfCmd(_) => unreachable!(),
     };
 
     if let Err(e) = result {

--- a/crates/lineark/src/version_check.rs
+++ b/crates/lineark/src/version_check.rs
@@ -1,0 +1,136 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const GITHUB_REPO: &str = "flipbit03/lineark";
+const CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
+
+/// Cached version check result.
+#[derive(Debug, Serialize, Deserialize)]
+struct VersionCache {
+    checked_at: u64,
+    latest_version: String,
+}
+
+/// Returns the path to the version cache file (~/.config/lineark/latest_version_check.json).
+fn cache_path() -> Option<PathBuf> {
+    // Use XDG_CONFIG_HOME if set, otherwise ~/.config
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| home::home_dir().map(|h| h.join(".config")));
+    config_dir.map(|d| d.join("lineark").join("latest_version_check.json"))
+}
+
+/// Read the cached version check, if it exists and is valid JSON.
+fn read_cache() -> Option<VersionCache> {
+    let path = cache_path()?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Write the version cache to disk, creating parent directories as needed.
+fn write_cache(cache: &VersionCache) {
+    if let Some(path) = cache_path() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(cache).unwrap_or_default(),
+        );
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Fetch the latest release version from GitHub.
+async fn fetch_latest_version() -> Result<String> {
+    let url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let client = reqwest::Client::new();
+    let resp: serde_json::Value = client
+        .get(&url)
+        .header("User-Agent", "lineark-self-update")
+        .send()
+        .await
+        .context("failed to reach GitHub API")?
+        .error_for_status()
+        .context("GitHub API returned an error")?
+        .json()
+        .await
+        .context("failed to parse GitHub API response")?;
+
+    let tag = resp["tag_name"]
+        .as_str()
+        .context("no tag_name in GitHub release")?;
+    Ok(tag.strip_prefix('v').unwrap_or(tag).to_string())
+}
+
+/// Get the latest version, using cache unless `force` is true.
+///
+/// - `force = false`: returns cached value if fresh (< 24h), otherwise fetches.
+/// - `force = true`: always fetches from GitHub.
+///
+/// Returns `None` only if both the network request and cache are unavailable.
+pub async fn get_latest_version(force: bool) -> Option<String> {
+    if !force {
+        if let Some(cache) = read_cache() {
+            if now_secs().saturating_sub(cache.checked_at) < CACHE_TTL_SECS {
+                return Some(cache.latest_version);
+            }
+        }
+    }
+
+    match fetch_latest_version().await {
+        Ok(version) => {
+            write_cache(&VersionCache {
+                checked_at: now_secs(),
+                latest_version: version.clone(),
+            });
+            Some(version)
+        }
+        Err(_) => {
+            // Network failed — return stale cache if available.
+            read_cache().map(|c| c.latest_version)
+        }
+    }
+}
+
+/// Returns the current compiled-in version of lineark.
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Returns true if this is a dev build (version 0.0.0).
+pub fn is_dev_build() -> bool {
+    current_version() == "0.0.0"
+}
+
+/// Returns the download URL for a GitHub release asset for the current platform.
+pub fn release_asset_url(tag: &str) -> Result<String> {
+    let os_tag = match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "macos",
+        _ => anyhow::bail!("unsupported OS: {}", std::env::consts::OS),
+    };
+    let arch_tag = match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        _ => anyhow::bail!("unsupported architecture: {}", std::env::consts::ARCH),
+    };
+
+    if os_tag == "macos" && arch_tag == "x86_64" {
+        anyhow::bail!("macOS x86_64 binaries are not provided — use `cargo install lineark`");
+    }
+
+    Ok(format!(
+        "https://github.com/{GITHUB_REPO}/releases/download/v{tag}/lineark_{os_tag}_{arch_tag}"
+    ))
+}

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -585,3 +585,52 @@ fn cycles_read_rejects_inf() {
         .failure()
         .stderr(predicate::str::contains("--team"));
 }
+
+// ── Self command ─────────────────────────────────────────────────────────────
+
+#[test]
+fn self_help_shows_update_subcommand() {
+    lineark()
+        .args(["self", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("update"));
+}
+
+#[test]
+fn self_update_help_shows_check_flag() {
+    lineark()
+        .args(["self", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--check"));
+}
+
+#[test]
+fn self_update_dev_build_exits_cleanly() {
+    // Dev builds have version 0.0.0 — self update should print a message and succeed.
+    lineark()
+        .args(["self", "update"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("dev build"));
+}
+
+#[test]
+fn self_update_check_dev_build_exits_cleanly() {
+    lineark()
+        .args(["self", "update", "--check"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("dev build"));
+}
+
+#[test]
+fn usage_includes_self_update_commands() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("self update"))
+        .stdout(predicate::str::contains("--check"));
+}


### PR DESCRIPTION
## Summary

- Adds `lineark self update` command that detects install method via compile-time `binary-release` feature flag and updates accordingly (GitHub Releases download vs `cargo install`)
- Adds `lineark self update --check` to check for updates without installing
- Implements cached version check (`~/.config/lineark/latest_version_check.json`, 24h TTL) that surfaces update hints in both `lineark usage` and `lineark --help`
- Dev builds (0.0.0) skip all version checking and self-update gracefully
- Updates release workflow to pass `--features binary-release` for pre-built binaries

## Test plan

- [x] `make check` passes (fmt, clippy, docs, build)
- [x] `make test` passes (54 offline + 89 SDK + 38 codegen tests)
- [x] `lineark self update` on dev build prints message and exits cleanly
- [x] `lineark self update --check` on dev build prints message and exits cleanly
- [x] `lineark self --help` shows `update` subcommand
- [x] `lineark usage` includes `self update` commands
- [ ] Release build with `--features binary-release`: binary mode update (needs actual release)
- [ ] Release build without feature: cargo mode update (needs crates.io publish)

Closes #52