### PR TITLE
fix: nested tokio runtime panic on `lineark --help`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,7 @@ dependencies = [
  "percent-encoding",
  "predicates",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "tabled",
@@ -1371,6 +1372,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/crates/lineark/Cargo.toml
+++ b/crates/lineark/Cargo.toml
@@ -23,6 +23,7 @@ colored = "2"
 anyhow = "1"
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
+semver = "1"
 uuid = "1"
 percent-encoding = "2"
 home = "0.5"

--- a/crates/lineark/src/commands/self_cmd.rs
+++ b/crates/lineark/src/commands/self_cmd.rs
@@ -41,7 +41,7 @@ async fn run_update(args: UpdateArgs) -> Result<()> {
         .context("could not determine the latest version")?;
 
     if args.check {
-        if current == latest {
+        if !version_check::is_newer(current, &latest) {
             println!("lineark {} is already the latest version.", current.green());
         } else {
             println!(
@@ -54,7 +54,7 @@ async fn run_update(args: UpdateArgs) -> Result<()> {
         return Ok(());
     }
 
-    if current == latest {
+    if !version_check::is_newer(current, &latest) {
         println!("lineark {} is already the latest version.", current.green());
         return Ok(());
     }

--- a/crates/lineark/src/main.rs
+++ b/crates/lineark/src/main.rs
@@ -67,7 +67,7 @@ fn update_hint_blocking() -> String {
 pub fn format_update_hint(latest: Option<&str>) -> String {
     let current = version_check::current_version();
     match latest {
-        Some(v) if v != current => {
+        Some(v) if version_check::is_newer(current, v) => {
             format!("\nUpdate available: {current} → {v}\nRun `lineark self update` to upgrade.\n")
         }
         _ => String::new(),

--- a/crates/lineark/src/version_check.rs
+++ b/crates/lineark/src/version_check.rs
@@ -124,6 +124,17 @@ pub fn is_dev_build() -> bool {
     current_version() == "0.0.0"
 }
 
+/// Returns true if `latest` is newer than `current` using semver comparison.
+pub fn is_newer(current: &str, latest: &str) -> bool {
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(c), Ok(l)) => l > c,
+        _ => latest != current,
+    }
+}
+
 /// Returns the download URL for a GitHub release asset for the current platform.
 pub fn release_asset_url(tag: &str) -> Result<String> {
     let os_tag = match std::env::consts::OS {


### PR DESCRIPTION
## Summary

- Fixes panic when running `lineark` or `lineark --help` caused by `after_help` trying to spin up a second tokio runtime inside `#[tokio::main]`
- `--help` now reads the version cache file synchronously — no async, no runtime. If cache is stale/missing, no update hint is shown (online check happens in `usage` and `self update` instead)

Cherry-pick of 80f0252 from `feat/52-feat-lineark-self-update-command`.

## Test plan

- [x] `make check && make test` passes
- [x] `lineark --help` no longer panics