### PR TITLE
docs: wordsmith README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ curl -fsSL https://raw.githubusercontent.com/flipbit03/lineark/main/install.sh |
 
 Or via cargo: `cargo install lineark`
 
+To update to the latest version:
+
+```sh
+lineark self update
+```
+
 ### Authenticate
 
-Create a [Linear API token](https://linear.app/settings/account/security) and save it:
+Create a [Linear Personal API key](https://linear.app/settings/account/security) and save it:
 
 ```sh
 echo "lin_api_..." > ~/.linear_api_token


### PR DESCRIPTION
## Summary
- Fix "Linear API token" link text → "Linear Personal API key" to match Linear's actual UI
- Add `lineark self update` snippet to the install section

## Test plan
- [x] Verify link text renders correctly
- [x] Verify `self update` snippet is in the right place