### PR TITLE
feat: `lineark projects create` command

### DIFF
--- a/crates/lineark/src/commands/projects.rs
+++ b/crates/lineark/src/commands/projects.rs
@@ -1,9 +1,11 @@
 use clap::Args;
+use lineark_sdk::generated::inputs::ProjectCreateInput;
 use lineark_sdk::generated::types::Project;
-use lineark_sdk::Client;
-use serde::Serialize;
+use lineark_sdk::{Client, GraphQLFields};
+use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 
+use super::helpers::{resolve_team_ids, resolve_user_id};
 use crate::output::{self, Format};
 
 /// Manage projects.
@@ -14,9 +16,47 @@ pub struct ProjectsCmd {
 }
 
 #[derive(Debug, clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum ProjectsAction {
     /// List all projects.
     List,
+    /// Create a new project.
+    ///
+    /// Examples:
+    ///   lineark projects create "My Project" --team ENG
+    ///   lineark projects create "Q4 Initiative" --team ENG,DESIGN --description "Cross-team effort"
+    ///   lineark projects create "Alpha" --team ENG --lead "Jane Doe" --target-date 2026-06-01
+    Create {
+        /// Project name.
+        name: String,
+        /// Team(s) to associate with (key, name, or UUID). Required. Comma-separated for multiple.
+        #[arg(long, required = true, value_delimiter = ',')]
+        team: Vec<String>,
+        /// Project description (markdown).
+        #[arg(short = 'd', long)]
+        description: Option<String>,
+        /// Project lead: user name, display name, or UUID.
+        #[arg(long)]
+        lead: Option<String>,
+        /// Planned start date (YYYY-MM-DD).
+        #[arg(long)]
+        start_date: Option<String>,
+        /// Planned target/completion date (YYYY-MM-DD).
+        #[arg(long)]
+        target_date: Option<String>,
+        /// Priority: 0=none, 1=urgent, 2=high, 3=medium, 4=low.
+        #[arg(short = 'p', long, value_parser = clap::value_parser!(i64).range(0..=4))]
+        priority: Option<i64>,
+        /// Markdown content for the project.
+        #[arg(long)]
+        content: Option<String>,
+        /// Project icon (emoji or icon name).
+        #[arg(long)]
+        icon: Option<String>,
+        /// Project color (hex color code).
+        #[arg(long)]
+        color: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize, Tabled)]
@@ -24,6 +64,16 @@ pub struct ProjectRow {
     pub id: String,
     pub name: String,
     pub slug_id: String,
+}
+
+/// Lean result type for project mutations.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Project)]
+#[serde(rename_all = "camelCase", default)]
+struct ProjectRef {
+    id: Option<String>,
+    name: Option<String>,
+    slug_id: Option<String>,
 }
 
 pub async fn run(cmd: ProjectsCmd, client: &Client, format: Format) -> anyhow::Result<()> {
@@ -47,6 +97,56 @@ pub async fn run(cmd: ProjectsCmd, client: &Client, format: Format) -> anyhow::R
                 .collect();
 
             output::print_table(&rows, format);
+        }
+        ProjectsAction::Create {
+            name,
+            team,
+            description,
+            lead,
+            start_date,
+            target_date,
+            priority,
+            content,
+            icon,
+            color,
+        } => {
+            let team_ids = resolve_team_ids(client, &team).await?;
+
+            let lead_id = match lead {
+                Some(ref l) => Some(resolve_user_id(client, l).await?),
+                None => None,
+            };
+
+            let start_date = start_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid start-date (expected YYYY-MM-DD): {}", e))?;
+
+            let target_date = target_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid target-date (expected YYYY-MM-DD): {}", e))?;
+
+            let input = ProjectCreateInput {
+                name: Some(name),
+                team_ids: Some(team_ids),
+                description,
+                lead_id,
+                start_date,
+                target_date,
+                priority,
+                content,
+                icon,
+                color,
+                ..Default::default()
+            };
+
+            let project = client
+                .project_create::<ProjectRef>(None, input)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&project, format);
         }
     }
     Ok(())

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -28,6 +28,11 @@ COMMANDS:
   lineark teams list                               List all teams
   lineark users list [--active]                    List users
   lineark projects list                            List all projects
+  lineark projects create <NAME> --team KEY[,KEY]  Create a new project
+    [--description TEXT] [--lead NAME-OR-ID]        Description, project lead
+    [--start-date DATE] [--target-date DATE]        Dates (YYYY-MM-DD)
+    [-p 0-4] [--content TEXT]                       Priority, markdown content
+    [--icon ICON] [--color COLOR]                   Icon, color
   lineark labels list [--team KEY]                  List issue labels (includes team key)
   lineark cycles list [-l N] [--team KEY]          List cycles
     [--active]                                     Only the active cycle

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -377,6 +377,59 @@ fn documents_update_no_flags_prints_error() {
         .stderr(predicate::str::contains("No update fields provided"));
 }
 
+// ── Projects ────────────────────────────────────────────────────────────────
+
+#[test]
+fn projects_help_shows_subcommands() {
+    lineark()
+        .args(["projects", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("create"));
+}
+
+#[test]
+fn projects_create_help_shows_flags() {
+    lineark()
+        .args(["projects", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--team"))
+        .stdout(predicate::str::contains("--description"))
+        .stdout(predicate::str::contains("--lead"))
+        .stdout(predicate::str::contains("--start-date"))
+        .stdout(predicate::str::contains("--target-date"))
+        .stdout(predicate::str::contains("--priority"))
+        .stdout(predicate::str::contains("--content"))
+        .stdout(predicate::str::contains("--icon"))
+        .stdout(predicate::str::contains("--color"));
+}
+
+#[test]
+fn projects_create_requires_team_flag() {
+    lineark()
+        .args([
+            "--api-token",
+            "fake-token",
+            "projects",
+            "create",
+            "My Project",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--team"));
+}
+
+#[test]
+fn usage_includes_projects_create() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("projects create"));
+}
+
 // ── Project milestones ──────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #79

- Add `lineark projects create <NAME> --team KEY[,KEY,...]` command to create Linear projects from the CLI
- Add `resolve_team_ids` helper for batch team name/key/UUID resolution (fetches teams list once)
- Support flags: `--description`, `--lead`, `--start-date`, `--target-date`, `--priority`, `--content`, `--icon`, `--color`
- Teams accept keys, names, or UUIDs — comma-separated for multi-team projects
- Update `lineark usage` command reference with new `projects create` entry

## Test plan

- [x] 4 new offline tests: help output, flag validation, team required, usage reference
- [x] 1 new online test: full create → list → verify → delete lifecycle
- [x] All 213 existing tests continue to pass (`make check && make test`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo doc --workspace` clean