### PR TITLE
fix: release workflow uses tag_name instead of GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Patch version in Cargo.toml files
         run: |
@@ -94,6 +98,8 @@ jobs:
             asset: lineark_macos_aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -116,7 +122,9 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Patch version in Cargo.toml files
         run: |


### PR DESCRIPTION
## Summary

The v0.9.0 release failed because `GITHUB_REF_NAME` resolved to `main` instead of the tag name, causing the version `sed` replacement to produce an empty string.

**Root cause:** For v0.9.0 the GitHub Actions run had `headBranch: "main"` instead of `headBranch: "v0.9.0"` (all previous successful releases had the tag as headBranch). This made `GITHUB_REF_NAME` = `main` and `${GITHUB_REF_NAME#v}` = `main`, which then failed the sed/cargo flow.

**Fix:** Use `github.event.release.tag_name` (from the release event payload) instead of `GITHUB_REF_NAME` for version extraction. Also explicitly checkout the tag ref in `actions/checkout`. The workflow already used `github.event.release.tag_name` on line 156 for the upload step — now all jobs use it consistently.

## Test plan

- [x] Merge, delete the v0.9.0 release + tag, re-create with `gh release create v0.9.0 --generate-notes`