### PR TITLE
chore: add `.worktrees/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary

Ignore `.worktrees/` directory to support git worktree-based development.

## Test plan

- `.worktrees/` directories are ignored by git