### PR TITLE
fix: add RAII cleanup guards to all online tests

### DIFF
--- a/.github/workflows/ci-online-fork.yml
+++ b/.github/workflows/ci-online-fork.yml
@@ -15,6 +15,11 @@ env:
 jobs:
   test-online:
     name: Tests (Online)
+    # Share the same concurrency group as the main CI online tests — only one
+    # online test run at a time across all workflows, to avoid resource conflicts.
+    concurrency:
+      group: linear-online-tests
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     if: >-
       github.event.label.name == 'safe-to-test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,12 @@ jobs:
     name: Tests (Online)
     # Skip on fork PRs — secrets are unavailable. Use safe-to-test label instead.
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Online tests share a single Linear workspace — never run two at the same time.
+    # cancel-in-progress: false queues new runs and waits for the current one to finish,
+    # so we don't kill a run mid-flight and leak resources.
+    concurrency:
+      group: linear-online-tests
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add Drop-based RAII guards (`TeamGuard`, `IssueGuard`, `ProjectGuard`, `DocumentGuard`) to all three online test files, ensuring resources are cleaned up even on panic
- Serialize team-creating tests with a mutex to prevent exceeding Linear workspace plan limits during parallel test execution
- Fix membership tests to handle "already a member" responses gracefully

## Details
Online tests that create resources (teams, issues, projects, documents) previously had no safety net — if a test panicked before reaching the explicit delete call, the resource leaked. Teams were the worst offender since Linear's free/standard plan has a hard team limit, and orphaned teams accumulated until all team tests started failing.

**Changes across all 3 test files:**
- `crates/lineark/tests/online.rs` — CLI integration tests (24 guard insertions, `std::sync::Mutex` for team serialization)
- `crates/lineark-sdk/tests/online.rs` — SDK async tests (10 guard insertions, `tokio::sync::Mutex` for async-safe team serialization)
- `crates/lineark-sdk/tests/blocking_online.rs` — SDK blocking tests (3 guard insertions)

## Test plan
- [x] `cargo test --workspace` — all tests pass (43 CLI online, 34 SDK async online, 13 SDK blocking, plus all offline/unit tests)
- [x] Verified guards fire on panic (resource is deleted even if test assertion fails)
- [x] Verified team mutex prevents "plan limit reached" errors during parallel runs
- [x] Manually cleaned up orphaned test team from workspace

Closes #98