### PR TITLE
fix: dynamically resolve second user in team membership tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ make check                               # lint + doc + build (no tests)
 make test                                # run tests only
 ```
 
+**Online tests must run serially.** They hit the live Linear API, which has plan-level limits (e.g. max teams). Running them in parallel causes spurious failures from resource exhaustion. Always use `-- --test-threads=1` when running online tests locally:
+
+```bash
+cargo test -p lineark-sdk --test online -- --test-threads=1
+cargo test -p lineark --test online -- --test-threads=1
+```
+
 ## Updating the schema
 
 `schema/schema.graphql` is a vendored copy of Linear's public GraphQL schema (SDL). It's checked in for reproducible builds and reviewable diffs. To update it:


### PR DESCRIPTION
## Summary

- **SDK test** (`team_membership_create_and_delete`): now discovers a different workspace user via `whoami` + `users().last(250)` and adds/removes *that* user instead of `"me"` (who is auto-added as team creator)
- **CLI test** (`teams_members_add_and_remove`): same approach via `whoami` + `users list` CLI commands, then passes the other user's ID to `--user`
- Both tests fail early with a clear message if the workspace has only one user
- No user IDs, names, or emails are hardcoded

## Test plan

- [x] `make check` passes (fmt, clippy, doc, build)
- [x] SDK online test `team_membership_create_and_delete` passes — exercises successful add + remove
- [x] CLI online test `teams_members_add_and_remove` passes — exercises successful add + remove via CLI
- [x] All 34 SDK online tests pass
- [x] All 76 CLI offline tests pass

Closes #100