### PR TITLE
docs: update READMEs for team CRUD, membership, and comment delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ That's it. Your agent discovers all commands at runtime by running `lineark usag
 
 | Area | Commands |
 |------|----------|
-| **Issues** | `list`, `read`, `search`, `create`, `update`, `archive`, `delete` |
-| **Comments** | `create` on any issue |
+| **Issues** | `list`, `read`, `search`, `create`, `update`, `archive`, `unarchive`, `delete` |
+| **Comments** | `create`, `delete` |
 | **Projects** | `list`, `read`, `create` |
 | **Milestones** | `list`, `read`, `create`, `update`, `delete` |
 | **Cycles** | `list`, `read` |
 | **Documents** | `list`, `read`, `create`, `update`, `delete` |
-| **Teams / Users / Labels** | `list` |
+| **Teams** | `list`, `read`, `create`, `update`, `delete`, `members add`, `members remove` |
+| **Users / Labels** | `list` |
 | **File embeds** | `upload`, `download` |
 
 Every command supports `--help` for full details. Most flags accept human-readable names — `--team ENG`, `--assignee "Jane Doe"`, `--labels "Bug,P0"` — no UUIDs required.

--- a/crates/lineark-sdk/README.md
+++ b/crates/lineark-sdk/README.md
@@ -168,6 +168,7 @@ let payload = client.issue_create::<Issue>(IssueCreateInput {
 | `issue_unarchive(id)` | Unarchive a previously archived issue |
 | `issue_delete(permanently, id)` | Delete an issue |
 | `comment_create(input)` | Create a comment |
+| `comment_delete(id)` | Delete a comment |
 | `document_create(input)` | Create a document |
 | `document_update(input, id)` | Update a document |
 | `document_delete(id)` | Delete a document |
@@ -177,6 +178,11 @@ let payload = client.issue_create::<Issue>(IssueCreateInput {
 | `project_milestone_create(input)` | Create a project milestone |
 | `project_milestone_update(input, id)` | Update a project milestone |
 | `project_milestone_delete(id)` | Delete a project milestone |
+| `team_create(copy_settings_from_team_id, input)` | Create a team |
+| `team_update(mapping, input, id)` | Update a team |
+| `team_delete(id)` | Delete a team |
+| `team_membership_create(input)` | Create a team membership |
+| `team_membership_delete(also_leave_parent_teams, id)` | Delete a team membership |
 | `issue_relation_create(override_created_at, input)` | Create an issue relation |
 | `file_upload(meta, public, size, type, name)` | Request a signed upload URL |
 | `image_upload_from_url(url)` | Upload image from URL |
@@ -205,7 +211,7 @@ For non-async contexts, enable the `blocking` feature:
 lineark-sdk = { version = "...", features = ["blocking"] }
 ```
 
-The blocking client mirrors the async API exactly:
+The blocking client mirrors the async API for all queries and most mutations:
 
 ```rust
 use lineark_sdk::blocking_client::Client;

--- a/crates/lineark/README.md
+++ b/crates/lineark/README.md
@@ -39,6 +39,14 @@ Most flags accept human-readable names or UUIDs — `--team` accepts key/name/UU
 ```
 lineark whoami                                   Show authenticated user
 lineark teams list                               List all teams
+lineark teams read <ID>                          Full team detail (members, settings)
+lineark teams create <NAME>                      Create a team
+  [--key KEY] [--description TEXT] ...           See --help for all options
+lineark teams update <ID>                        Update a team
+  [--name NAME] [--key KEY] ...                  See --help for all options
+lineark teams delete <ID>                        Delete a team
+lineark teams members add <TEAM> --user USER     Add a user to a team
+lineark teams members remove <TEAM> --user USER  Remove a user from a team
 lineark users list [--active]                    List users
 lineark projects list [--led-by-me]              List all projects (with lead)
 lineark projects read <NAME-OR-ID>               Full project detail (lead, members, status, dates, teams)
@@ -67,6 +75,7 @@ lineark issues archive <IDENTIFIER>              Archive an issue
 lineark issues unarchive <IDENTIFIER>            Unarchive an issue
 lineark issues delete <IDENTIFIER>               Delete (trash) an issue
 lineark comments create <ISSUE-ID> --body TEXT   Comment on an issue
+lineark comments delete <ID>                     Delete a comment
 lineark documents list [--limit N]               List documents (lean output)
   [--project NAME-OR-ID] [--issue ID]            Filter by project or issue
 lineark documents read <ID>                      Read document (includes content)


### PR DESCRIPTION
## Summary
- Add missing team management commands (`read`, `create`, `update`, `delete`, `members add/remove`) to CLI and top-level READMEs
- Add missing SDK mutations (`comment_delete`, `team_create`, `team_update`, `team_delete`, `team_membership_create`, `team_membership_delete`)
- Add `comments delete` to CLI README
- Add `unarchive` to Issues row in top-level README
- Fix "mirrors the async API exactly" claim for blocking client

## Test plan
- [x] Verify rendered markdown looks correct on the PR diff