### PR TITLE
feat: `relations` command for all issue relation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ That's it. Your agent discovers all commands at runtime by running `lineark usag
 |------|----------|
 | **Issues** | `list`, `read`, `search`, `create`, `update`, `archive`, `unarchive`, `delete` |
 | **Comments** | `create`, `delete` |
+| **Relations** | `create` (blocks, blocked-by, related, duplicate, similar), `delete` |
 | **Projects** | `list`, `read`, `create` |
 | **Milestones** | `list`, `read`, `create`, `update`, `delete` |
 | **Cycles** | `list`, `read` |

--- a/crates/lineark-sdk/README.md
+++ b/crates/lineark-sdk/README.md
@@ -184,6 +184,7 @@ let payload = client.issue_create::<Issue>(IssueCreateInput {
 | `team_membership_create(input)` | Create a team membership |
 | `team_membership_delete(also_leave_parent_teams, id)` | Delete a team membership |
 | `issue_relation_create(override_created_at, input)` | Create an issue relation |
+| `issue_relation_delete(id)` | Delete an issue relation |
 | `file_upload(meta, public, size, type, name)` | Request a signed upload URL |
 | `image_upload_from_url(url)` | Upload image from URL |
 

--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -396,6 +396,13 @@ impl Client {
         crate::generated::mutations::issue_relation_create::<T>(self, override_created_at, input)
             .await
     }
+    /// Deletes an issue relation.
+    pub async fn issue_relation_delete(
+        &self,
+        id: String,
+    ) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::issue_relation_delete(self, id).await
+    }
     /// Creates a new document.
     ///
     /// Full type: [`Document`](super::types::Document)

--- a/crates/lineark-sdk/src/generated/mutations.rs
+++ b/crates/lineark-sdk/src/generated/mutations.rs
@@ -405,6 +405,21 @@ pub async fn issue_relation_create<
         .execute_mutation::<T>(&query, variables, "issueRelationCreate", "issueRelation")
         .await
 }
+/// Deletes an issue relation.
+pub async fn issue_relation_delete(
+    client: &Client,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string(), "entityId".to_string()];
+    let query = String::from(
+        "mutation IssueRelationDelete($id: String!) { issueRelationDelete(id: $id) { ",
+    ) + &response_parts.join(" ")
+        + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "issueRelationDelete")
+        .await
+}
 /// Creates a new document.
 ///
 /// Full type: [`Document`](super::types::Document)

--- a/crates/lineark/README.md
+++ b/crates/lineark/README.md
@@ -76,6 +76,11 @@ lineark issues unarchive <IDENTIFIER>            Unarchive an issue
 lineark issues delete <IDENTIFIER>               Delete (trash) an issue
 lineark comments create <ISSUE-ID> --body TEXT   Comment on an issue
 lineark comments delete <ID>                     Delete a comment
+lineark relations create <ISSUE>                 Create an issue relation
+  --blocks <ISSUE>                               Source blocks target
+  --blocked-by <ISSUE>                           Source is blocked by target
+  --related/--duplicate/--similar <ISSUE>        Other relation types
+lineark relations delete <RELATION-UUID>         Delete an issue relation
 lineark documents list [--limit N]               List documents (lean output)
   [--project NAME-OR-ID] [--issue ID]            Filter by project or issue
 lineark documents read <ID>                      Read document (includes content)

--- a/crates/lineark/src/commands/mod.rs
+++ b/crates/lineark/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod issues;
 pub mod labels;
 pub mod milestones;
 pub mod projects;
+pub mod relations;
 pub mod self_cmd;
 pub mod teams;
 pub mod usage;

--- a/crates/lineark/src/commands/relations.rs
+++ b/crates/lineark/src/commands/relations.rs
@@ -1,0 +1,124 @@
+use clap::Args;
+use lineark_sdk::generated::enums::IssueRelationType;
+use lineark_sdk::generated::inputs::IssueRelationCreateInput;
+use lineark_sdk::generated::types::IssueRelation;
+use lineark_sdk::{Client, GraphQLFields};
+use serde::{Deserialize, Serialize};
+
+use super::helpers::resolve_issue_id;
+use crate::output::{self, Format};
+
+/// Manage issue relations (blocking, related, duplicate, similar).
+#[derive(Debug, Args)]
+pub struct RelationsCmd {
+    #[command(subcommand)]
+    pub action: RelationsAction,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum RelationsAction {
+    /// Create a relation between two issues.
+    ///
+    /// Exactly one relation flag is required: --blocks, --blocked-by, --related,
+    /// --duplicate, or --similar.
+    ///
+    /// Examples:
+    ///   lineark relations create ENG-100 --blocks ENG-101
+    ///   lineark relations create ENG-100 --blocked-by ENG-99
+    ///   lineark relations create ENG-100 --related ENG-200
+    ///   lineark relations create ENG-100 --duplicate ENG-200
+    ///   lineark relations create ENG-100 --similar ENG-200
+    Create {
+        /// Source issue identifier (e.g., ENG-123) or UUID.
+        issue: String,
+        /// The source issue blocks the specified issue.
+        #[arg(long, group = "relation_type")]
+        blocks: Option<String>,
+        /// The source issue is blocked by the specified issue.
+        #[arg(long, group = "relation_type")]
+        blocked_by: Option<String>,
+        /// The source issue is related to the specified issue.
+        #[arg(long, group = "relation_type")]
+        related: Option<String>,
+        /// The source issue is a duplicate of the specified issue.
+        #[arg(long, group = "relation_type")]
+        duplicate: Option<String>,
+        /// The source issue is similar to the specified issue.
+        #[arg(long, group = "relation_type")]
+        similar: Option<String>,
+    },
+    /// Delete an issue relation.
+    ///
+    /// Examples:
+    ///   lineark relations delete RELATION-UUID
+    Delete {
+        /// Relation UUID (visible in `lineark issues read` output).
+        id: String,
+    },
+}
+
+/// Lean result type for relation mutations.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = IssueRelation)]
+#[serde(rename_all = "camelCase", default)]
+struct RelationRef {
+    id: Option<String>,
+    r#type: Option<String>,
+}
+
+pub async fn run(cmd: RelationsCmd, client: &Client, format: Format) -> anyhow::Result<()> {
+    match cmd.action {
+        RelationsAction::Create {
+            issue,
+            blocks,
+            blocked_by,
+            related,
+            duplicate,
+            similar,
+        } => {
+            // Determine relation type and target issue.
+            let (relation_type, source, target) = if let Some(ref target) = blocks {
+                (IssueRelationType::Blocks, &issue, target)
+            } else if let Some(ref blocker) = blocked_by {
+                // "A is blocked by B" means "B blocks A" — swap source and target.
+                (IssueRelationType::Blocks, blocker, &issue)
+            } else if let Some(ref target) = related {
+                (IssueRelationType::Related, &issue, target)
+            } else if let Some(ref target) = duplicate {
+                (IssueRelationType::Duplicate, &issue, target)
+            } else if let Some(ref target) = similar {
+                (IssueRelationType::Similar, &issue, target)
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Exactly one relation flag is required: --blocks, --blocked-by, --related, --duplicate, or --similar."
+                ));
+            };
+
+            let source_id = resolve_issue_id(client, source).await?;
+            let target_id = resolve_issue_id(client, target).await?;
+
+            let input = IssueRelationCreateInput {
+                issue_id: Some(source_id),
+                related_issue_id: Some(target_id),
+                r#type: Some(relation_type),
+                ..Default::default()
+            };
+
+            let relation = client
+                .issue_relation_create::<RelationRef>(None, input)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&relation, format);
+        }
+        RelationsAction::Delete { id } => {
+            client
+                .issue_relation_delete(id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&serde_json::json!({ "success": true }), format);
+        }
+    }
+    Ok(())
+}

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -77,6 +77,13 @@ COMMANDS:
     [--permanently]                                Permanently delete instead of trashing
   lineark comments create <ISSUE-ID> --body TEXT   Comment on an issue
   lineark comments delete <COMMENT-UUID>           Delete a comment
+  lineark relations create <ISSUE>                 Create an issue relation
+    --blocks <ISSUE>                               Source blocks target
+    --blocked-by <ISSUE>                           Source is blocked by target
+    --related <ISSUE>                              Mark issues as related
+    --duplicate <ISSUE>                            Mark as duplicate
+    --similar <ISSUE>                              Mark as similar
+  lineark relations delete <RELATION-UUID>         Delete an issue relation
   lineark documents list [--limit N]               List documents (lean output)
     [--project NAME-OR-ID] [--issue ID]            Filter by project or issue
   lineark documents read <ID>                      Read document (includes content)

--- a/crates/lineark/src/main.rs
+++ b/crates/lineark/src/main.rs
@@ -39,6 +39,8 @@ enum Command {
     Issues(commands::issues::IssuesCmd),
     /// Manage comments.
     Comments(commands::comments::CommentsCmd),
+    /// Manage issue relations (blocking, related, duplicate, similar).
+    Relations(commands::relations::RelationsCmd),
     /// Manage documents.
     Documents(commands::documents::DocumentsCmd),
     /// Manage project milestones.
@@ -117,6 +119,7 @@ async fn main() {
         Command::Cycles(cmd) => commands::cycles::run(cmd, &client, format).await,
         Command::Issues(cmd) => commands::issues::run(cmd, &client, format).await,
         Command::Comments(cmd) => commands::comments::run(cmd, &client, format).await,
+        Command::Relations(cmd) => commands::relations::run(cmd, &client, format).await,
         Command::Documents(cmd) => commands::documents::run(cmd, &client, format).await,
         Command::Embeds(cmd) => commands::embeds::run(cmd, &client, format).await,
         Command::ProjectMilestones(cmd) => commands::milestones::run(cmd, &client, format).await,

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -3096,4 +3096,284 @@ mod online {
         // Clean up: delete the team.
         delete_team(&team_id);
     }
+
+    // ── Relations ────────────────────────────────────────────────────────────
+
+    /// Helper: create two test issues, returning their UUIDs and guards.
+    fn create_two_issues(
+        token: &str,
+        team_key: &str,
+    ) -> ((String, IssueGuard), (String, IssueGuard)) {
+        let out1 = lineark()
+            .args([
+                "--api-token",
+                token,
+                "--format",
+                "json",
+                "issues",
+                "create",
+                "[test] relation issue A",
+                "--team",
+                team_key,
+                "--priority",
+                "4",
+            ])
+            .output()
+            .unwrap();
+        assert!(out1.status.success(), "issue A creation should succeed");
+        let a: serde_json::Value = serde_json::from_slice(&out1.stdout).unwrap();
+        let a_id = a["id"].as_str().unwrap().to_string();
+        let a_guard = IssueGuard {
+            token: token.to_string(),
+            id: a_id.clone(),
+        };
+
+        let out2 = lineark()
+            .args([
+                "--api-token",
+                token,
+                "--format",
+                "json",
+                "issues",
+                "create",
+                "[test] relation issue B",
+                "--team",
+                team_key,
+                "--priority",
+                "4",
+            ])
+            .output()
+            .unwrap();
+        assert!(out2.status.success(), "issue B creation should succeed");
+        let b: serde_json::Value = serde_json::from_slice(&out2.stdout).unwrap();
+        let b_id = b["id"].as_str().unwrap().to_string();
+        let b_guard = IssueGuard {
+            token: token.to_string(),
+            id: b_id.clone(),
+        };
+
+        ((a_id, a_guard), (b_id, b_guard))
+    }
+
+    /// Helper: get the first team key.
+    fn first_team_key(token: &str) -> String {
+        let output = lineark()
+            .args(["--api-token", token, "--format", "json", "teams", "list"])
+            .output()
+            .unwrap();
+        let teams: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        teams[0]["key"].as_str().unwrap().to_string()
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_blocks() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--blocks",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create --blocks should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(rel.get("id").is_some(), "relation should have an id");
+        assert_eq!(rel["type"].as_str(), Some("blocks"));
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_blocked_by() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        // "A --blocked-by B" means B blocks A.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--blocked-by",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create --blocked-by should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(rel.get("id").is_some(), "relation should have an id");
+        assert_eq!(rel["type"].as_str(), Some("blocks"));
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_related() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--related",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create --related should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(rel.get("id").is_some(), "relation should have an id");
+        assert_eq!(rel["type"].as_str(), Some("related"));
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_duplicate() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--duplicate",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create --duplicate should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(rel.get("id").is_some(), "relation should have an id");
+        assert_eq!(rel["type"].as_str(), Some("duplicate"));
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_similar() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--similar",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create --similar should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(rel.get("id").is_some(), "relation should have an id");
+        assert_eq!(rel["type"].as_str(), Some("similar"));
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn relations_create_and_delete() {
+        let token = api_token();
+        let team_key = first_team_key(&token);
+        let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
+
+        // Create a relation.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "create",
+                &a_id,
+                "--blocks",
+                &b_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let rel: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        let rel_id = rel["id"]
+            .as_str()
+            .expect("relation should have id")
+            .to_string();
+
+        // Delete the relation.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "relations",
+                "delete",
+                &rel_id,
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "relations delete should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let result: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(result["success"].as_bool(), Some(true));
+    }
 }

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -41,6 +41,7 @@ documentDelete = true
 fileUpload = true
 imageUploadFromUrl = true
 issueRelationCreate = true
+issueRelationDelete = true
 projectMilestoneCreate = true
 projectMilestoneUpdate = true
 projectMilestoneDelete = true


### PR DESCRIPTION
## Summary

- Adds `lineark relations create` and `lineark relations delete` CLI commands covering **all** Linear issue relation types: `--blocks`, `--blocked-by`, `--related`, `--duplicate`, `--similar`
- `--blocked-by` is a convenience flag that swaps source/target and uses the `blocks` relation type under the hood
- Adds `issueRelationDelete` to `operations.toml` and regenerates the SDK to expose the delete mutation
- Updates `lineark usage` command reference with the new commands

## What was already supported (unchanged)

- **Parent/child (sub-issue)** relationships via `issues create --parent` / `issues update --parent` / `issues update --clear-parent` — these are a separate mechanism from relations and were already fully implemented
- **Reading** relations in `issues read` output — already worked
- **SDK-level** `issue_relation_create` — already generated, but had no CLI command

## Test plan

- [x] `make check` passes (fmt, clippy, doc, build)
- [x] All 76 offline CLI tests pass
- [x] All 49 online CLI tests pass (7 new relation tests)
- [x] All SDK tests pass (offline + online)
- [x] New online tests create their own resources and clean up via RAII guards (IssueGuard deletes both issues on drop, which cascades relation deletion)
- [x] Tests cover: `--blocks`, `--blocked-by`, `--related`, `--duplicate`, `--similar`, and create+delete lifecycle