### PR TITLE
feat: show inverse relations and source issue in `issues read`

### DIFF
--- a/crates/lineark/src/commands/issues.rs
+++ b/crates/lineark/src/commands/issues.rs
@@ -326,6 +326,8 @@ pub struct IssueDetail {
     #[graphql(nested)]
     pub relations: Option<RelationConnection>,
     #[graphql(nested)]
+    pub inverse_relations: Option<RelationConnection>,
+    #[graphql(nested)]
     pub children: Option<ChildrenConnection>,
     #[graphql(nested)]
     pub comments: Option<CommentsConnection>,
@@ -371,6 +373,8 @@ pub struct RelationConnection {
 pub struct RelationNode {
     pub id: Option<String>,
     pub r#type: Option<String>,
+    #[graphql(nested)]
+    pub issue: Option<RelatedIssueRef>,
     #[graphql(nested)]
     pub related_issue: Option<RelatedIssueRef>,
 }


### PR DESCRIPTION
## Summary

- Adds `inverseRelations` to the `issues read` output so both directions of a relation are visible
- Adds the `issue` (source) field to each relation node, so inverse relations clearly show *who* the other issue is

Before this change, if A blocks B:
- `issues read A` showed the relation in `relations` ✅
- `issues read B` showed **nothing** — the inverse direction was missing ❌

After:
- `issues read A` → `relations` shows "A blocks B" with `issue: A, relatedIssue: B`
- `issues read B` → `inverseRelations` shows the same relation with `issue: A, relatedIssue: B`
- Both sides expose the **same relation UUID** for use with `relations delete`

## Test plan

- [x] `make check` passes
- [x] All 7 relation online tests pass
- [x] Manually verified: create relation → read both sides → delete → read both sides clean → cleanup