### PR TITLE
feat: `documents search` and `projects search` commands

### DIFF
--- a/crates/lineark-sdk/src/blocking_client.rs
+++ b/crates/lineark-sdk/src/blocking_client.rs
@@ -248,6 +248,20 @@ blocking_query_builder! {
 }
 
 blocking_query_builder! {
+    query_type = SearchDocumentsQueryBuilder,
+    node_type = DocumentSearchResult,
+    return_type = Connection<DocumentSearchResult>,
+    methods = [before(impl Into<String>), after(impl Into<String>), first(i64), last(i64), include_archived(bool), include_comments(bool), team_id(impl Into<String>)]
+}
+
+blocking_query_builder! {
+    query_type = SearchProjectsQueryBuilder,
+    node_type = ProjectSearchResult,
+    return_type = Connection<ProjectSearchResult>,
+    methods = [before(impl Into<String>), after(impl Into<String>), first(i64), last(i64), include_archived(bool), include_comments(bool), team_id(impl Into<String>)]
+}
+
+blocking_query_builder! {
     query_type = DocumentsQueryBuilder,
     node_type = Document,
     return_type = Connection<Document>,
@@ -353,6 +367,34 @@ impl Client {
     {
         BlockingQuery::new(
             self.inner.search_issues::<IssueSearchResult>(term),
+            &self.rt,
+        )
+    }
+
+    /// Search documents (blocking).
+    pub fn search_documents(
+        &self,
+        term: impl Into<String>,
+    ) -> BlockingQuery<
+        '_,
+        crate::generated::queries::SearchDocumentsQueryBuilder<'_, DocumentSearchResult>,
+    > {
+        BlockingQuery::new(
+            self.inner.search_documents::<DocumentSearchResult>(term),
+            &self.rt,
+        )
+    }
+
+    /// Search projects (blocking).
+    pub fn search_projects(
+        &self,
+        term: impl Into<String>,
+    ) -> BlockingQuery<
+        '_,
+        crate::generated::queries::SearchProjectsQueryBuilder<'_, ProjectSearchResult>,
+    > {
+        BlockingQuery::new(
+            self.inner.search_projects::<ProjectSearchResult>(term),
             &self.rt,
         )
     }

--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -63,6 +63,21 @@ impl Client {
     ) -> Result<T, LinearError> {
         crate::generated::queries::team::<T>(self, id).await
     }
+    /// Search documents.
+    ///
+    /// Full type: [`DocumentSearchResult`](super::types::DocumentSearchResult)
+    pub fn search_documents<T>(
+        &self,
+        term: impl Into<String>,
+    ) -> SearchDocumentsQueryBuilder<'_, T> {
+        crate::generated::queries::search_documents(self, term)
+    }
+    /// Search projects.
+    ///
+    /// Full type: [`ProjectSearchResult`](super::types::ProjectSearchResult)
+    pub fn search_projects<T>(&self, term: impl Into<String>) -> SearchProjectsQueryBuilder<'_, T> {
+        crate::generated::queries::search_projects(self, term)
+    }
     /// Search issues.
     ///
     /// Full type: [`IssueSearchResult`](super::types::IssueSearchResult)

--- a/crates/lineark-sdk/src/generated/queries.rs
+++ b/crates/lineark-sdk/src/generated/queries.rs
@@ -384,6 +384,200 @@ impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::Team>>
             .await
     }
 }
+/// Query builder: Search documents.
+///
+/// Full type: [`DocumentSearchResult`](super::types::DocumentSearchResult)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct SearchDocumentsQueryBuilder<'a, T> {
+    client: &'a Client,
+    term: String,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    include_comments: Option<bool>,
+    team_id: Option<String>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::DocumentSearchResult>>
+    SearchDocumentsQueryBuilder<'a, T>
+{
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub fn include_comments(mut self, value: bool) -> Self {
+        self.include_comments = Some(value);
+        self
+    }
+    pub fn team_id(mut self, value: impl Into<String>) -> Self {
+        self.team_id = Some(value.into());
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        map.insert("term".to_string(), serde_json::json!(self.term));
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_comments {
+            map.insert("includeComments".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.team_id {
+            map.insert("teamId".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "SearchDocuments",
+            "$before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy, $term: String!, $includeComments: Boolean, $teamId: String",
+            "searchDocuments",
+            "before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy, term: $term, includeComments: $includeComments, teamId: $teamId",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "searchDocuments")
+            .await
+    }
+}
+/// Query builder: Search projects.
+///
+/// Full type: [`ProjectSearchResult`](super::types::ProjectSearchResult)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct SearchProjectsQueryBuilder<'a, T> {
+    client: &'a Client,
+    term: String,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    include_comments: Option<bool>,
+    team_id: Option<String>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::ProjectSearchResult>>
+    SearchProjectsQueryBuilder<'a, T>
+{
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub fn include_comments(mut self, value: bool) -> Self {
+        self.include_comments = Some(value);
+        self
+    }
+    pub fn team_id(mut self, value: impl Into<String>) -> Self {
+        self.team_id = Some(value.into());
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        map.insert("term".to_string(), serde_json::json!(self.term));
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_comments {
+            map.insert("includeComments".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.team_id {
+            map.insert("teamId".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "SearchProjects",
+            "$before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy, $term: String!, $includeComments: Boolean, $teamId: String",
+            "searchProjects",
+            "before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy, term: $term, includeComments: $includeComments, teamId: $teamId",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "searchProjects")
+            .await
+    }
+}
 /// Query builder: Search issues.
 ///
 /// Full type: [`IssueSearchResult`](super::types::IssueSearchResult)
@@ -1118,6 +1312,48 @@ pub async fn team<T: DeserializeOwned + GraphQLFields<FullType = super::types::T
         "Team", "$id: String!", "team", "id: $id", selection
     );
     client.execute::<T>(&query, variables, "team").await
+}
+/// Search documents.
+///
+/// Full type: [`DocumentSearchResult`](super::types::DocumentSearchResult)
+pub fn search_documents<'a, T>(
+    client: &'a Client,
+    term: impl Into<String>,
+) -> SearchDocumentsQueryBuilder<'a, T> {
+    SearchDocumentsQueryBuilder {
+        client,
+        term: term.into(),
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        include_comments: None,
+        team_id: None,
+        _marker: std::marker::PhantomData,
+    }
+}
+/// Search projects.
+///
+/// Full type: [`ProjectSearchResult`](super::types::ProjectSearchResult)
+pub fn search_projects<'a, T>(
+    client: &'a Client,
+    term: impl Into<String>,
+) -> SearchProjectsQueryBuilder<'a, T> {
+    SearchProjectsQueryBuilder {
+        client,
+        term: term.into(),
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        include_comments: None,
+        team_id: None,
+        _marker: std::marker::PhantomData,
+    }
 }
 /// Search issues.
 ///

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -42,6 +42,8 @@ COMMANDS:
   lineark users list [--active]                    List users
   lineark projects list [--led-by-me]              List all projects (with lead)
   lineark projects read <NAME-OR-ID>               Full project detail (lead, members, status, dates, teams)
+  lineark projects search <QUERY> [-l N]           Full-text search projects
+    [--team KEY]                                   Filter by team
   lineark projects create <NAME> --team KEY[,KEY]  Create a new project
     [--description TEXT] [--lead NAME-OR-ID|me]    Description, project lead
     [--members NAME,...|me]                        Project members (comma-separated)
@@ -87,6 +89,8 @@ COMMANDS:
   lineark documents list [--limit N]               List documents (lean output)
     [--project NAME-OR-ID] [--issue ID]            Filter by project or issue
   lineark documents read <ID>                      Read document (includes content)
+  lineark documents search <QUERY> [-l N]          Full-text search documents
+    [--team KEY]                                   Filter by team
   lineark documents create --title TEXT            Create a document
     [--content TEXT] [--project NAME-OR-ID]        Project name or UUID
     [--issue ID]

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -187,6 +187,7 @@ fn documents_help_shows_subcommands() {
         .success()
         .stdout(predicate::str::contains("list"))
         .stdout(predicate::str::contains("read"))
+        .stdout(predicate::str::contains("search"))
         .stdout(predicate::str::contains("create"))
         .stdout(predicate::str::contains("update"))
         .stdout(predicate::str::contains("delete"));
@@ -392,6 +393,7 @@ fn projects_help_shows_subcommands() {
         .success()
         .stdout(predicate::str::contains("list"))
         .stdout(predicate::str::contains("read"))
+        .stdout(predicate::str::contains("search"))
         .stdout(predicate::str::contains("create"));
 }
 
@@ -886,4 +888,46 @@ fn usage_includes_comments_delete() {
         .assert()
         .success()
         .stdout(predicate::str::contains("comments delete"));
+}
+
+// ── Documents search ────────────────────────────────────────────────────────
+
+#[test]
+fn documents_search_help_shows_flags() {
+    lineark()
+        .args(["documents", "search", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--team"))
+        .stdout(predicate::str::contains("--limit"));
+}
+
+#[test]
+fn usage_includes_documents_search() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("documents search"));
+}
+
+// ── Projects search ─────────────────────────────────────────────────────────
+
+#[test]
+fn projects_search_help_shows_flags() {
+    lineark()
+        .args(["projects", "search", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--team"))
+        .stdout(predicate::str::contains("--limit"));
+}
+
+#[test]
+fn usage_includes_projects_search() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("projects search"));
 }

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -12,6 +12,8 @@ cycles = true
 cycle = true
 issueLabels = true
 searchIssues = true
+searchDocuments = true
+searchProjects = true
 workflowStates = true
 
 # Phase 3 — Rich features


### PR DESCRIPTION
## Summary

- Add `searchDocuments` and `searchProjects` queries to `operations.toml` and regenerate SDK
- Add blocking client wrappers for both search queries
- New CLI subcommands:
  - `lineark documents search <QUERY> [-l N] [--team KEY]` — full-text search across documents
  - `lineark projects search <QUERY> [-l N] [--team KEY]` — full-text search across projects
- Follows the established `searchIssues` pattern with lean types, table output, and team filtering
- Add `DocumentGuard` RAII struct and `retry_search_with_backoff` helper for online tests
- Update `lineark usage` reference

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all offline tests pass (80)
- [x] CLI online tests pass: basic search, create-then-find with retry, `--team` filter
- [x] Manual smoke: `documents search`, `projects search`, team filter all work
- [ ] SDK online tests blocked by #105 — pre-existing test panics and aborts the `test_with` runner before new tests execute

> **Blocker**: #105 must be resolved for the full SDK online test suite to run.