### PR TITLE
feat: cycle create, update, and archive commands

### DIFF
--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -440,4 +440,41 @@ impl Client {
     ) -> Result<T, LinearError> {
         crate::generated::mutations::document_delete::<T>(self, id).await
     }
+    /// Creates a new cycle.
+    ///
+    /// Full type: [`Cycle`](super::types::Cycle)
+    pub async fn cycle_create<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+    >(
+        &self,
+        input: CycleCreateInput,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::cycle_create::<T>(self, input).await
+    }
+    /// Updates a cycle.
+    ///
+    /// Full type: [`Cycle`](super::types::Cycle)
+    pub async fn cycle_update<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+    >(
+        &self,
+        input: CycleUpdateInput,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::cycle_update::<T>(self, input, id).await
+    }
+    /// Archives a cycle.
+    ///
+    /// Full type: [`Cycle`](super::types::Cycle)
+    pub async fn cycle_archive<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+    >(
+        &self,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::cycle_archive::<T>(self, id).await
+    }
 }

--- a/crates/lineark-sdk/src/generated/mutations.rs
+++ b/crates/lineark-sdk/src/generated/mutations.rs
@@ -476,3 +476,59 @@ pub async fn document_delete<
         .execute_mutation::<T>(&query, variables, "documentDelete", "entity")
         .await
 }
+/// Creates a new cycle.
+///
+/// Full type: [`Cycle`](super::types::Cycle)
+pub async fn cycle_create<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+>(
+    client: &Client,
+    input: CycleCreateInput,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "input" : input });
+    let query = String::from(
+        "mutation CycleCreate($input: CycleCreateInput!) { cycleCreate(input: $input) { success cycle { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "cycleCreate", "cycle")
+        .await
+}
+/// Updates a cycle.
+///
+/// Full type: [`Cycle`](super::types::Cycle)
+pub async fn cycle_update<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+>(
+    client: &Client,
+    input: CycleUpdateInput,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "input" : input, "id" : id });
+    let query = String::from(
+        "mutation CycleUpdate($input: CycleUpdateInput!, $id: String!) { cycleUpdate(input: $input, id: $id) { success cycle { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "cycleUpdate", "cycle")
+        .await
+}
+/// Archives a cycle.
+///
+/// Full type: [`Cycle`](super::types::Cycle)
+pub async fn cycle_archive<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Cycle>,
+>(
+    client: &Client,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let query = String::from(
+        "mutation CycleArchive($id: String!) { cycleArchive(id: $id) { success entity { ",
+    ) + &T::selection()
+        + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "cycleArchive", "entity")
+        .await
+}

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -55,9 +55,9 @@ COMMANDS:
   lineark cycles read <ID> [--team KEY]            Read cycle (UUID, name, or number)
   lineark cycles create --team KEY                 Create a cycle
     --starts-at DATE --ends-at DATE                Dates (YYYY-MM-DD)
-    [--name TEXT] [--description TEXT]              Optional name and description
+    [--name TEXT] [--description TEXT]             Optional name and description
   lineark cycles update <ID>                       Update a cycle
-    [--name TEXT] [--description TEXT]              Name, description
+    [--name TEXT] [--description TEXT]             Name, description
     [--starts-at DATE] [--ends-at DATE]            Dates (YYYY-MM-DD)
   lineark cycles archive <ID>                      Archive a cycle
   lineark issues list [-l N] [--team KEY]          Active issues (done/canceled hidden), newest first

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -53,6 +53,13 @@ COMMANDS:
     [--active]                                     Only the active cycle
     [--around-active N]                            Active ± N neighbors
   lineark cycles read <ID> [--team KEY]            Read cycle (UUID, name, or number)
+  lineark cycles create --team KEY                 Create a cycle
+    --starts-at DATE --ends-at DATE                Dates (YYYY-MM-DD)
+    [--name TEXT] [--description TEXT]              Optional name and description
+  lineark cycles update <ID>                       Update a cycle
+    [--name TEXT] [--description TEXT]              Name, description
+    [--starts-at DATE] [--ends-at DATE]            Dates (YYYY-MM-DD)
+  lineark cycles archive <ID>                      Archive a cycle
   lineark issues list [-l N] [--team KEY]          Active issues (done/canceled hidden), newest first
     [--mine]                                       Only issues assigned to me
     [--show-done]                                  Include done/canceled issues

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -254,7 +254,10 @@ fn cycles_help_shows_subcommands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("list"))
-        .stdout(predicate::str::contains("read"));
+        .stdout(predicate::str::contains("read"))
+        .stdout(predicate::str::contains("create"))
+        .stdout(predicate::str::contains("update"))
+        .stdout(predicate::str::contains("archive"));
 }
 
 #[test]
@@ -276,6 +279,41 @@ fn cycles_read_help_shows_team_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--team"));
+}
+
+#[test]
+fn cycles_create_help_shows_flags() {
+    lineark()
+        .args(["cycles", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--team"))
+        .stdout(predicate::str::contains("--starts-at"))
+        .stdout(predicate::str::contains("--ends-at"));
+}
+
+#[test]
+fn cycles_update_no_flags_prints_error() {
+    lineark()
+        .args([
+            "--api-token",
+            "fake-token",
+            "cycles",
+            "update",
+            "00000000-0000-0000-0000-000000000000",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No update fields provided"));
+}
+
+#[test]
+fn cycles_archive_help_shows_id() {
+    lineark()
+        .args(["cycles", "archive", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<ID>"));
 }
 
 // ── Usage includes Phase 3 commands ─────────────────────────────────────────
@@ -311,6 +349,17 @@ fn usage_includes_cycles_flags() {
         .success()
         .stdout(predicate::str::contains("--active"))
         .stdout(predicate::str::contains("--around-active"));
+}
+
+#[test]
+fn usage_includes_cycles_crud() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cycles create"))
+        .stdout(predicate::str::contains("cycles update"))
+        .stdout(predicate::str::contains("cycles archive"));
 }
 
 // ── Labels ──────────────────────────────────────────────────────────────────

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -53,3 +53,6 @@ teamUpdate = true
 teamDelete = true
 teamMembershipCreate = true
 teamMembershipDelete = true
+cycleCreate = true
+cycleUpdate = true
+cycleArchive = true


### PR DESCRIPTION
## Summary
- Add `cycles create`, `cycles update`, and `cycles archive` CLI subcommands
- Generate `cycleCreate`, `cycleUpdate`, `cycleArchive` SDK mutations via codegen
- Include offline tests (help output, validation) and online tests (full CRUD lifecycle)

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` passes
- [x] Offline tests pass (4 new)
- [x] SDK online tests pass (`cycle_create_update_and_archive`)
- [x] CLI online tests pass (`cycles_create_update_and_archive`)

> **Note:** Online tests depend on #105 (configurable test team env var) for reliable execution against workspaces where the first team alphabetically is non-functional.