### PR TITLE
feat: notifications list, read, mark-read, archive, and unarchive

### DIFF
--- a/crates/lineark-codegen/src/parser.rs
+++ b/crates/lineark-codegen/src/parser.rs
@@ -163,7 +163,14 @@ pub fn parse(schema_text: &str) -> ParsedSchema {
             }
             cst::Definition::InterfaceTypeDefinition(i) => {
                 let name = extract_name(&i.name());
+                let description = extract_description(&i.description());
                 type_kind_map.insert(name.clone(), TypeKind::Interface);
+                let fields = extract_fields(&i.fields_definition());
+                objects.push(ObjectDef {
+                    name,
+                    description,
+                    fields,
+                });
             }
             cst::Definition::UnionTypeDefinition(u) => {
                 let name = extract_name(&u.name());

--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -86,6 +86,23 @@ impl Client {
     ) -> Result<T, LinearError> {
         crate::generated::queries::project_milestone::<T>(self, id).await
     }
+    /// All notifications.
+    ///
+    /// Full type: [`Notification`](super::types::Notification)
+    pub fn notifications<T>(&self) -> NotificationsQueryBuilder<'_, T> {
+        crate::generated::queries::notifications(self)
+    }
+    /// One specific notification.
+    ///
+    /// Full type: [`Notification`](super::types::Notification)
+    pub async fn notification<
+        T: DeserializeOwned + GraphQLFields<FullType = super::types::Notification>,
+    >(
+        &self,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::queries::notification::<T>(self, id).await
+    }
     /// All issues.
     ///
     /// Full type: [`Issue`](super::types::Issue)
@@ -318,6 +335,25 @@ impl Client {
         id: String,
     ) -> Result<serde_json::Value, LinearError> {
         crate::generated::mutations::project_milestone_delete(self, id).await
+    }
+    /// Updates a notification.
+    pub async fn notification_update(
+        &self,
+        input: NotificationUpdateInput,
+        id: String,
+    ) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::notification_update(self, input, id).await
+    }
+    /// Archives a notification.
+    pub async fn notification_archive(&self, id: String) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::notification_archive(self, id).await
+    }
+    /// Unarchives a notification.
+    pub async fn notification_unarchive(
+        &self,
+        id: String,
+    ) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::notification_unarchive(self, id).await
     }
     /// Creates a new issue.
     ///

--- a/crates/lineark-sdk/src/generated/mutations.rs
+++ b/crates/lineark-sdk/src/generated/mutations.rs
@@ -288,6 +288,51 @@ pub async fn project_milestone_delete(
         .execute::<serde_json::Value>(&query, variables, "projectMilestoneDelete")
         .await
 }
+/// Updates a notification.
+pub async fn notification_update(
+    client: &Client,
+    input: NotificationUpdateInput,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "input" : input, "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string()];
+    let query = String::from(
+        "mutation NotificationUpdate($input: NotificationUpdateInput!, $id: String!) { notificationUpdate(input: $input, id: $id) { ",
+    ) + &response_parts.join(" ") + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "notificationUpdate")
+        .await
+}
+/// Archives a notification.
+pub async fn notification_archive(
+    client: &Client,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string()];
+    let query = String::from(
+        "mutation NotificationArchive($id: String!) { notificationArchive(id: $id) { ",
+    ) + &response_parts.join(" ")
+        + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "notificationArchive")
+        .await
+}
+/// Unarchives a notification.
+pub async fn notification_unarchive(
+    client: &Client,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string()];
+    let query = String::from(
+        "mutation NotificationUnarchive($id: String!) { notificationUnarchive(id: $id) { ",
+    ) + &response_parts.join(" ")
+        + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "notificationUnarchive")
+        .await
+}
 /// Creates a new issue.
 ///
 /// Full type: [`Issue`](super::types::Issue)

--- a/crates/lineark-sdk/src/generated/queries.rs
+++ b/crates/lineark-sdk/src/generated/queries.rs
@@ -576,6 +576,93 @@ impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::ProjectMil
             .await
     }
 }
+/// Query builder: All notifications.
+///
+/// Full type: [`Notification`](super::types::Notification)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct NotificationsQueryBuilder<'a, T> {
+    client: &'a Client,
+    filter: Option<NotificationFilter>,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::Notification>>
+    NotificationsQueryBuilder<'a, T>
+{
+    pub fn filter(mut self, value: NotificationFilter) -> Self {
+        self.filter = Some(value);
+        self
+    }
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        if let Some(ref v) = self.filter {
+            map.insert("filter".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "Notifications",
+            "$filter: NotificationFilter, $before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy",
+            "notifications",
+            "filter: $filter, before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "notifications")
+            .await
+    }
+}
 /// Query builder: All issues.
 ///
 /// Full type: [`Issue`](super::types::Issue)
@@ -1175,6 +1262,39 @@ pub async fn project_milestone<
     client
         .execute::<T>(&query, variables, "projectMilestone")
         .await
+}
+/// All notifications.
+///
+/// Full type: [`Notification`](super::types::Notification)
+pub fn notifications<'a, T>(client: &'a Client) -> NotificationsQueryBuilder<'a, T> {
+    NotificationsQueryBuilder {
+        client,
+        filter: None,
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        _marker: std::marker::PhantomData,
+    }
+}
+/// One specific notification.
+///
+/// Full type: [`Notification`](super::types::Notification)
+pub async fn notification<
+    T: DeserializeOwned + GraphQLFields<FullType = super::types::Notification>,
+>(
+    client: &Client,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let selection = T::selection();
+    let query = format!(
+        "query {}({}) {{ {}({}) {{ {} }} }}",
+        "Notification", "$id: String!", "notification", "id: $id", selection
+    );
+    client.execute::<T>(&query, variables, "notification").await
 }
 /// All issues.
 ///

--- a/crates/lineark-sdk/src/generated/types.rs
+++ b/crates/lineark-sdk/src/generated/types.rs
@@ -4,6 +4,165 @@
 use super::enums::*;
 use crate::field_selection::GraphQLFields;
 use serde::{Deserialize, Serialize};
+/// A generic payload return from entity archive or deletion mutations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ArchivePayload {
+    /// The identifier of the last sync operation.
+    pub last_sync_id: Option<f64>,
+    /// Whether the operation was successful.
+    pub success: Option<bool>,
+}
+impl GraphQLFields for ArchivePayload {
+    type FullType = Self;
+    fn selection() -> String {
+        "lastSyncId success".into()
+    }
+}
+/// A basic entity.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Entity {
+    /// The unique identifier of the entity.
+    pub id: Option<String>,
+    /// The time at which the entity was created.
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+    /// been updated after creation.
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time at which the entity was archived. Null if the entity has not been archived.
+    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+impl GraphQLFields for Entity {
+    type FullType = Self;
+    fn selection() -> String {
+        "id createdAt updatedAt archivedAt".into()
+    }
+}
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Node {
+    /// The unique identifier of the entity.
+    pub id: Option<String>,
+}
+impl GraphQLFields for Node {
+    type FullType = Self;
+    fn selection() -> String {
+        "id".into()
+    }
+}
+/// A notification sent to a user.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Notification {
+    /// The unique identifier of the entity.
+    pub id: Option<String>,
+    /// The time at which the entity was created.
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+    /// been updated after creation.
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time at which the entity was archived. Null if the entity has not been archived.
+    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Notification type.
+    pub r#type: Option<String>,
+    /// The user that caused the notification.
+    pub actor: Option<Box<User>>,
+    /// The external user that caused the notification.
+    pub external_user_actor: Option<Box<ExternalUser>>,
+    /// The user that received the notification.
+    pub user: Option<Box<User>>,
+    /// The time at when the user marked the notification as read. Null, if the the user hasn't read the notification
+    pub read_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time at when an email reminder for this notification was sent to the user. Null, if no email
+    /// reminder has been sent.
+    pub emailed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time until a notification will be snoozed. After that it will appear in the inbox again.
+    pub snoozed_until_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time at which a notification was unsnoozed..
+    pub unsnoozed_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The category of the notification.
+    pub category: Option<NotificationCategory>,
+    /// `Internal` URL to the target of the notification.
+    pub url: Option<String>,
+    /// `Internal` Inbox URL for the notification.
+    pub inbox_url: Option<String>,
+    /// `Internal` Notification title.
+    pub title: Option<String>,
+    /// `Internal` Notification subtitle.
+    pub subtitle: Option<String>,
+    /// `Internal` If notification actor was Linear.
+    pub is_linear_actor: Option<bool>,
+    /// `Internal` Notification avatar URL.
+    pub actor_avatar_url: Option<String>,
+    /// `Internal` Notification actor initials if avatar is not available.
+    pub actor_initials: Option<String>,
+    /// `Internal` Notification actor initials if avatar is not available.
+    pub actor_avatar_color: Option<String>,
+    /// `Internal` Issue's status type for issue notifications.
+    pub issue_status_type: Option<String>,
+    /// `Internal` Project update health for new updates.
+    pub project_update_health: Option<String>,
+    /// `Internal` Initiative update health for new updates.
+    pub initiative_update_health: Option<String>,
+    /// `Internal` Notifications with the same grouping key will be grouped together in the UI.
+    pub grouping_key: Option<String>,
+    /// `Internal` Priority of the notification with the same grouping key. Higher number means higher priority. If priority is the same, notifications should be sorted by `createdAt`.
+    pub grouping_priority: Option<f64>,
+    /// The bot that caused the notification.
+    pub bot_actor: Option<Box<ActorBot>>,
+}
+impl GraphQLFields for Notification {
+    type FullType = Self;
+    fn selection() -> String {
+        "id createdAt updatedAt archivedAt type readAt emailedAt snoozedUntilAt unsnoozedAt category url inboxUrl title subtitle isLinearActor actorAvatarUrl actorInitials actorAvatarColor issueStatusType projectUpdateHealth initiativeUpdateHealth groupingKey groupingPriority"
+            .into()
+    }
+}
+/// Notification subscriptions for models.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct NotificationSubscription {
+    /// The unique identifier of the entity.
+    pub id: Option<String>,
+    /// The time at which the entity was created.
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+    /// been updated after creation.
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The time at which the entity was archived. Null if the entity has not been archived.
+    pub archived_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// The user that subscribed to receive notifications.
+    pub subscriber: Option<Box<User>>,
+    /// The customer associated with the notification subscription.
+    pub customer: Option<Box<Customer>>,
+    /// The contextual custom view associated with the notification subscription.
+    pub custom_view: Option<Box<CustomView>>,
+    /// The contextual cycle view associated with the notification subscription.
+    pub cycle: Option<Box<Cycle>>,
+    /// The contextual label view associated with the notification subscription.
+    pub label: Option<Box<IssueLabel>>,
+    /// The contextual project view associated with the notification subscription.
+    pub project: Option<Box<Project>>,
+    /// The contextual initiative view associated with the notification subscription.
+    pub initiative: Option<Box<Initiative>>,
+    /// The team associated with the notification subscription.
+    pub team: Option<Box<Team>>,
+    /// The user view associated with the notification subscription.
+    pub user: Option<Box<User>>,
+    /// The type of view to which the notification subscription context is associated with.
+    pub context_view_type: Option<ContextViewType>,
+    /// The type of user view to which the notification subscription context is associated with.
+    pub user_context_view_type: Option<UserContextViewType>,
+    /// Whether the subscription is active or not.
+    pub active: Option<bool>,
+}
+impl GraphQLFields for NotificationSubscription {
+    type FullType = Self;
+    fn selection() -> String {
+        "id createdAt updatedAt archivedAt contextViewType userContextViewType active".into()
+    }
+}
 /// `Internal` An access key for CI/CD integrations.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
@@ -5294,6 +5453,8 @@ pub struct IssueNotification {
     pub parent_comment: Option<Box<Comment>>,
     /// The team related to the issue notification.
     pub team: Option<Box<Team>>,
+    /// The subscriptions related to the notification.
+    pub subscriptions: Option<Box<Vec<NotificationSubscription>>>,
 }
 impl GraphQLFields for IssueNotification {
     type FullType = Self;
@@ -5920,6 +6081,8 @@ pub struct NotificationArchivePayload {
     pub last_sync_id: Option<f64>,
     /// Whether the operation was successful.
     pub success: Option<bool>,
+    /// The archived/unarchived entity. Null if entity was deleted.
+    pub entity: Option<Box<Notification>>,
 }
 impl GraphQLFields for NotificationArchivePayload {
     type FullType = Self;
@@ -5932,6 +6095,8 @@ impl GraphQLFields for NotificationArchivePayload {
 pub struct NotificationBatchActionPayload {
     /// The identifier of the last sync operation.
     pub last_sync_id: Option<f64>,
+    /// The notifications that were updated.
+    pub notifications: Option<Box<Vec<Notification>>>,
     /// Whether the operation was successful.
     pub success: Option<bool>,
 }
@@ -6005,6 +6170,7 @@ impl GraphQLFields for NotificationChannelPreferences {
 #[serde(rename_all = "camelCase", default)]
 pub struct NotificationConnection {
     pub edges: Option<Box<Vec<NotificationEdge>>>,
+    pub nodes: Option<Box<Vec<Notification>>>,
     pub page_info: Option<Box<PageInfo>>,
 }
 impl GraphQLFields for NotificationConnection {
@@ -6086,6 +6252,7 @@ impl GraphQLFields for NotificationDeliveryPreferencesSchedule {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NotificationEdge {
+    pub node: Option<Box<Notification>>,
     /// Used in `before` and `after` args
     pub cursor: Option<String>,
 }
@@ -6100,6 +6267,8 @@ impl GraphQLFields for NotificationEdge {
 pub struct NotificationPayload {
     /// The identifier of the last sync operation.
     pub last_sync_id: Option<f64>,
+    /// The notification that was created or updated.
+    pub notification: Option<Box<Notification>>,
     /// Whether the operation was successful.
     pub success: Option<bool>,
 }
@@ -6113,6 +6282,7 @@ impl GraphQLFields for NotificationPayload {
 #[serde(rename_all = "camelCase", default)]
 pub struct NotificationSubscriptionConnection {
     pub edges: Option<Box<Vec<NotificationSubscriptionEdge>>>,
+    pub nodes: Option<Box<Vec<NotificationSubscription>>>,
     pub page_info: Option<Box<PageInfo>>,
 }
 impl GraphQLFields for NotificationSubscriptionConnection {
@@ -6124,6 +6294,7 @@ impl GraphQLFields for NotificationSubscriptionConnection {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NotificationSubscriptionEdge {
+    pub node: Option<Box<NotificationSubscription>>,
     /// Used in `before` and `after` args
     pub cursor: Option<String>,
 }
@@ -6138,6 +6309,8 @@ impl GraphQLFields for NotificationSubscriptionEdge {
 pub struct NotificationSubscriptionPayload {
     /// The identifier of the last sync operation.
     pub last_sync_id: Option<f64>,
+    /// The notification subscription that was created or updated.
+    pub notification_subscription: Option<Box<NotificationSubscription>>,
     /// Whether the operation was successful.
     pub success: Option<bool>,
 }

--- a/crates/lineark-sdk/tests/online.rs
+++ b/crates/lineark-sdk/tests/online.rs
@@ -1061,6 +1061,54 @@ mod online {
         client.team_delete(team_id).await.unwrap();
     }
 
+    // ── Notifications ─────────────────────────────────────────────────────
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    async fn notifications_list() {
+        let client = test_client();
+        let conn = client
+            .notifications::<Notification>()
+            .first(10)
+            .send()
+            .await
+            .unwrap();
+        // Connection should deserialize; may be empty if no notifications.
+        let _ = conn.page_info;
+        for notification in &conn.nodes {
+            assert!(notification.id.is_some());
+        }
+    }
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    async fn notification_archive_and_unarchive() {
+        let client = test_client();
+        let conn = client
+            .notifications::<Notification>()
+            .first(5)
+            .send()
+            .await
+            .unwrap();
+
+        if conn.nodes.is_empty() {
+            // No notifications to test with — skip gracefully.
+            return;
+        }
+
+        let notification_id = conn.nodes[0].id.clone().unwrap();
+
+        // Archive the notification.
+        client
+            .notification_archive(notification_id.clone())
+            .await
+            .unwrap();
+
+        // Unarchive the notification.
+        client
+            .notification_unarchive(notification_id)
+            .await
+            .unwrap();
+    }
+
     // ── Error handling ──────────────────────────────────────────────────────
 
     #[test_with::runtime_ignore_if(no_online_test_token)]

--- a/crates/lineark/src/commands/mod.rs
+++ b/crates/lineark/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod helpers;
 pub mod issues;
 pub mod labels;
 pub mod milestones;
+pub mod notifications;
 pub mod projects;
 pub mod relations;
 pub mod self_cmd;

--- a/crates/lineark/src/commands/notifications.rs
+++ b/crates/lineark/src/commands/notifications.rs
@@ -1,0 +1,174 @@
+use clap::Args;
+use lineark_sdk::generated::inputs::NotificationUpdateInput;
+use lineark_sdk::generated::types::Notification;
+use lineark_sdk::{Client, GraphQLFields};
+use serde::{Deserialize, Serialize};
+use tabled::Tabled;
+
+use crate::output::{self, Format};
+
+/// Manage notifications.
+#[derive(Debug, Args)]
+pub struct NotificationsCmd {
+    #[command(subcommand)]
+    pub action: NotificationsAction,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum NotificationsAction {
+    /// List notifications.
+    ///
+    /// Examples:
+    ///   lineark notifications list
+    ///   lineark notifications list --unread
+    ///   lineark notifications list -l 10
+    List {
+        /// Maximum number of notifications to return (max 250).
+        #[arg(short = 'l', long, default_value = "50", value_parser = clap::value_parser!(i64).range(1..=250))]
+        limit: i64,
+        /// Show only unread notifications.
+        #[arg(long, default_value = "false")]
+        unread: bool,
+    },
+    /// Show full details for a single notification.
+    ///
+    /// Examples:
+    ///   lineark notifications read NOTIFICATION-UUID
+    Read {
+        /// Notification UUID.
+        id: String,
+    },
+    /// Mark a notification as read.
+    ///
+    /// Examples:
+    ///   lineark notifications mark-read NOTIFICATION-UUID
+    MarkRead {
+        /// Notification UUID.
+        id: String,
+    },
+    /// Archive a notification.
+    ///
+    /// Examples:
+    ///   lineark notifications archive NOTIFICATION-UUID
+    Archive {
+        /// Notification UUID.
+        id: String,
+    },
+    /// Unarchive a notification.
+    ///
+    /// Examples:
+    ///   lineark notifications unarchive NOTIFICATION-UUID
+    Unarchive {
+        /// Notification UUID.
+        id: String,
+    },
+}
+
+// ── Lean types ───────────────────────────────────────────────────────────────
+
+/// Lean notification type for list views.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Notification)]
+#[serde(rename_all = "camelCase", default)]
+struct NotificationSummary {
+    pub id: Option<String>,
+    pub r#type: Option<String>,
+    pub title: Option<String>,
+    pub read_at: Option<String>,
+    pub created_at: Option<String>,
+    pub url: Option<String>,
+}
+
+// ── List row ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Tabled)]
+struct NotificationRow {
+    id: String,
+    #[tabled(rename = "type")]
+    r#type: String,
+    title: String,
+    read: String,
+    created_at: String,
+}
+
+impl From<&NotificationSummary> for NotificationRow {
+    fn from(n: &NotificationSummary) -> Self {
+        Self {
+            id: n.id.clone().unwrap_or_default(),
+            r#type: n.r#type.clone().unwrap_or_default(),
+            title: n.title.clone().unwrap_or_default(),
+            read: if n.read_at.is_some() { "yes" } else { "no" }.to_string(),
+            created_at: n.created_at.clone().unwrap_or_default(),
+        }
+    }
+}
+
+// ── Command dispatch ─────────────────────────────────────────────────────────
+
+pub async fn run(cmd: NotificationsCmd, client: &Client, format: Format) -> anyhow::Result<()> {
+    match cmd.action {
+        NotificationsAction::List { limit, unread } => {
+            let conn = client
+                .notifications::<NotificationSummary>()
+                .first(limit)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            let nodes: Vec<&NotificationSummary> = if unread {
+                conn.nodes.iter().filter(|n| n.read_at.is_none()).collect()
+            } else {
+                conn.nodes.iter().collect()
+            };
+
+            match format {
+                Format::Json => {
+                    let json = serde_json::to_string_pretty(&nodes).unwrap_or_default();
+                    println!("{json}");
+                }
+                Format::Human => {
+                    let rows: Vec<NotificationRow> =
+                        nodes.iter().map(|n| NotificationRow::from(*n)).collect();
+                    output::print_table(&rows, format);
+                }
+            }
+        }
+        NotificationsAction::Read { id } => {
+            let notification = client
+                .notification::<Notification>(id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            output::print_one(&notification, format);
+        }
+        NotificationsAction::MarkRead { id } => {
+            let input = NotificationUpdateInput {
+                read_at: Some(chrono::Utc::now()),
+                ..Default::default()
+            };
+
+            let result = client
+                .notification_update(input, id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&result, format);
+        }
+        NotificationsAction::Archive { id } => {
+            let result = client
+                .notification_archive(id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&result, format);
+        }
+        NotificationsAction::Unarchive { id } => {
+            let result = client
+                .notification_unarchive(id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&result, format);
+        }
+    }
+    Ok(())
+}

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -110,6 +110,11 @@ COMMANDS:
                                                    --public only works for images (not SVG)
   lineark embeds download <URL>                    Download any file by URL (works with
     [--output PATH] [--overwrite]                  Linear CDN URLs and external URLs alike)
+  lineark notifications list [-l N] [--unread]     List notifications
+  lineark notifications read <ID>                  Full notification detail
+  lineark notifications mark-read <ID>             Mark a notification as read
+  lineark notifications archive <ID>               Archive a notification
+  lineark notifications unarchive <ID>             Unarchive a notification
   lineark self update                              Update lineark to the latest release
   lineark self update --check                      Check if an update is available
 

--- a/crates/lineark/src/main.rs
+++ b/crates/lineark/src/main.rs
@@ -47,6 +47,8 @@ enum Command {
     ProjectMilestones(commands::milestones::MilestonesCmd),
     /// Manage file embeds (download/upload).
     Embeds(commands::embeds::EmbedsCmd),
+    /// Manage notifications.
+    Notifications(commands::notifications::NotificationsCmd),
     /// Print a compact LLM-friendly command reference.
     Usage,
     /// Manage lineark itself (update, etc.).
@@ -122,6 +124,7 @@ async fn main() {
         Command::Relations(cmd) => commands::relations::run(cmd, &client, format).await,
         Command::Documents(cmd) => commands::documents::run(cmd, &client, format).await,
         Command::Embeds(cmd) => commands::embeds::run(cmd, &client, format).await,
+        Command::Notifications(cmd) => commands::notifications::run(cmd, &client, format).await,
         Command::ProjectMilestones(cmd) => commands::milestones::run(cmd, &client, format).await,
         Command::Usage | Command::SelfCmd(_) => unreachable!(),
     };

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -887,3 +887,68 @@ fn usage_includes_comments_delete() {
         .success()
         .stdout(predicate::str::contains("comments delete"));
 }
+
+// ── Notifications ────────────────────────────────────────────────────────────
+
+#[test]
+fn notifications_help_shows_subcommands() {
+    lineark()
+        .args(["notifications", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("read"))
+        .stdout(predicate::str::contains("mark-read"))
+        .stdout(predicate::str::contains("archive"))
+        .stdout(predicate::str::contains("unarchive"));
+}
+
+#[test]
+fn notifications_list_help_shows_flags() {
+    lineark()
+        .args(["notifications", "list", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--unread"))
+        .stdout(predicate::str::contains("--limit"));
+}
+
+#[test]
+fn notifications_mark_read_help_shows_id() {
+    lineark()
+        .args(["notifications", "mark-read", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<ID>"));
+}
+
+#[test]
+fn notifications_archive_help_shows_id() {
+    lineark()
+        .args(["notifications", "archive", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<ID>"));
+}
+
+#[test]
+fn notifications_unarchive_help_shows_id() {
+    lineark()
+        .args(["notifications", "unarchive", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<ID>"));
+}
+
+#[test]
+fn usage_includes_notifications_commands() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("notifications list"))
+        .stdout(predicate::str::contains("notifications read"))
+        .stdout(predicate::str::contains("notifications mark-read"))
+        .stdout(predicate::str::contains("notifications archive"))
+        .stdout(predicate::str::contains("notifications unarchive"));
+}

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -22,6 +22,10 @@ issueRelation = true
 projectMilestones = true
 projectMilestone = true
 
+# Notifications
+notifications = true
+notification = true
+
 [mutations]
 # Phase 2 — Core writes
 issueCreate = true
@@ -53,3 +57,8 @@ teamUpdate = true
 teamDelete = true
 teamMembershipCreate = true
 teamMembershipDelete = true
+
+# Notifications
+notificationUpdate = true
+notificationArchive = true
+notificationUnarchive = true


### PR DESCRIPTION
## Summary
- Add new top-level `notifications` command with list, read, mark-read, archive, and unarchive subcommands
- Enhance codegen to support GraphQL interface types (needed for `Notification`)
- Generate `notifications`, `notification` queries and `notificationUpdate`, `notificationArchive`, `notificationUnarchive` mutations
- Include offline tests (help output) and online tests (list + archive/unarchive round-trip)

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` passes
- [x] Offline tests pass (7 new)
- [x] SDK online tests pass (`notifications_list`, `notification_archive_and_unarchive`)
- [x] CLI online tests pass (`notifications_list_returns_json`, `notifications_archive_and_unarchive`)

> **Note:** Notifications are system-generated, so online tests work with existing notifications and skip gracefully if none exist.