### PR TITLE
feat: initiatives with full CRUD and project linking

### DIFF
--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -124,6 +124,23 @@ impl Client {
     pub fn issue_labels<T>(&self) -> IssueLabelsQueryBuilder<'_, T> {
         crate::generated::queries::issue_labels(self)
     }
+    /// All initiatives in the workspace.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub fn initiatives<T>(&self) -> InitiativesQueryBuilder<'_, T> {
+        crate::generated::queries::initiatives(self)
+    }
+    /// One specific initiative.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub async fn initiative<
+        T: DeserializeOwned + GraphQLFields<FullType = super::types::Initiative>,
+    >(
+        &self,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::queries::initiative::<T>(self, id).await
+    }
     /// All documents in the workspace.
     ///
     /// Full type: [`Document`](super::types::Document)
@@ -181,6 +198,25 @@ impl Client {
         url: String,
     ) -> Result<serde_json::Value, LinearError> {
         crate::generated::mutations::image_upload_from_url(self, url).await
+    }
+    /// Creates a new initiativeToProject join.
+    ///
+    /// Full type: [`InitiativeToProject`](super::types::InitiativeToProject)
+    pub async fn initiative_to_project_create<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::InitiativeToProject>,
+    >(
+        &self,
+        input: InitiativeToProjectCreateInput,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::initiative_to_project_create::<T>(self, input).await
+    }
+    /// Deletes a initiativeToProject.
+    pub async fn initiative_to_project_delete(
+        &self,
+        id: String,
+    ) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::initiative_to_project_delete(self, id).await
     }
     /// Creates a new comment.
     ///
@@ -402,6 +438,59 @@ impl Client {
         id: String,
     ) -> Result<serde_json::Value, LinearError> {
         crate::generated::mutations::issue_relation_delete(self, id).await
+    }
+    /// Creates a new initiative.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub async fn initiative_create<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+    >(
+        &self,
+        input: InitiativeCreateInput,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::initiative_create::<T>(self, input).await
+    }
+    /// Updates a initiative.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub async fn initiative_update<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+    >(
+        &self,
+        input: InitiativeUpdateInput,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::initiative_update::<T>(self, input, id).await
+    }
+    /// Archives a initiative.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub async fn initiative_archive<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+    >(
+        &self,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::initiative_archive::<T>(self, id).await
+    }
+    /// Unarchives a initiative.
+    ///
+    /// Full type: [`Initiative`](super::types::Initiative)
+    pub async fn initiative_unarchive<
+        T: serde::de::DeserializeOwned
+            + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+    >(
+        &self,
+        id: String,
+    ) -> Result<T, LinearError> {
+        crate::generated::mutations::initiative_unarchive::<T>(self, id).await
+    }
+    /// Deletes (trashes) an initiative.
+    pub async fn initiative_delete(&self, id: String) -> Result<serde_json::Value, LinearError> {
+        crate::generated::mutations::initiative_delete(self, id).await
     }
     /// Creates a new document.
     ///

--- a/crates/lineark-sdk/src/generated/mutations.rs
+++ b/crates/lineark-sdk/src/generated/mutations.rs
@@ -49,6 +49,44 @@ pub async fn image_upload_from_url(
         .execute::<serde_json::Value>(&query, variables, "imageUploadFromUrl")
         .await
 }
+/// Creates a new initiativeToProject join.
+///
+/// Full type: [`InitiativeToProject`](super::types::InitiativeToProject)
+pub async fn initiative_to_project_create<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::InitiativeToProject>,
+>(
+    client: &Client,
+    input: InitiativeToProjectCreateInput,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "input" : input });
+    let query = String::from(
+        "mutation InitiativeToProjectCreate($input: InitiativeToProjectCreateInput!) { initiativeToProjectCreate(input: $input) { success initiativeToProject { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(
+            &query,
+            variables,
+            "initiativeToProjectCreate",
+            "initiativeToProject",
+        )
+        .await
+}
+/// Deletes a initiativeToProject.
+pub async fn initiative_to_project_delete(
+    client: &Client,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string(), "entityId".to_string()];
+    let query = String::from(
+        "mutation InitiativeToProjectDelete($id: String!) { initiativeToProjectDelete(id: $id) { ",
+    ) + &response_parts.join(" ")
+        + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "initiativeToProjectDelete")
+        .await
+}
 /// Creates a new comment.
 ///
 /// Full type: [`Comment`](super::types::Comment)
@@ -418,6 +456,95 @@ pub async fn issue_relation_delete(
         + " } }";
     client
         .execute::<serde_json::Value>(&query, variables, "issueRelationDelete")
+        .await
+}
+/// Creates a new initiative.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub async fn initiative_create<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+>(
+    client: &Client,
+    input: InitiativeCreateInput,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "input" : input });
+    let query = String::from(
+        "mutation InitiativeCreate($input: InitiativeCreateInput!) { initiativeCreate(input: $input) { success initiative { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "initiativeCreate", "initiative")
+        .await
+}
+/// Updates a initiative.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub async fn initiative_update<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+>(
+    client: &Client,
+    input: InitiativeUpdateInput,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "input" : input, "id" : id });
+    let query = String::from(
+        "mutation InitiativeUpdate($input: InitiativeUpdateInput!, $id: String!) { initiativeUpdate(input: $input, id: $id) { success initiative { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "initiativeUpdate", "initiative")
+        .await
+}
+/// Archives a initiative.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub async fn initiative_archive<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+>(
+    client: &Client,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let query = String::from(
+        "mutation InitiativeArchive($id: String!) { initiativeArchive(id: $id) { success entity { ",
+    ) + &T::selection()
+        + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "initiativeArchive", "entity")
+        .await
+}
+/// Unarchives a initiative.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub async fn initiative_unarchive<
+    T: serde::de::DeserializeOwned
+        + crate::field_selection::GraphQLFields<FullType = super::types::Initiative>,
+>(
+    client: &Client,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let query = String::from(
+        "mutation InitiativeUnarchive($id: String!) { initiativeUnarchive(id: $id) { success entity { ",
+    ) + &T::selection() + " } } }";
+    client
+        .execute_mutation::<T>(&query, variables, "initiativeUnarchive", "entity")
+        .await
+}
+/// Deletes (trashes) an initiative.
+pub async fn initiative_delete(
+    client: &Client,
+    id: String,
+) -> Result<serde_json::Value, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let response_parts: Vec<String> = vec!["success".to_string(), "entityId".to_string()];
+    let query =
+        String::from("mutation InitiativeDelete($id: String!) { initiativeDelete(id: $id) { ")
+            + &response_parts.join(" ")
+            + " } }";
+    client
+        .execute::<serde_json::Value>(&query, variables, "initiativeDelete")
         .await
 }
 /// Creates a new document.

--- a/crates/lineark-sdk/src/generated/queries.rs
+++ b/crates/lineark-sdk/src/generated/queries.rs
@@ -837,6 +837,101 @@ impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::IssueLabel
             .await
     }
 }
+/// Query builder: All initiatives in the workspace.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct InitiativesQueryBuilder<'a, T> {
+    client: &'a Client,
+    filter: Option<InitiativeFilter>,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    sort: Option<InitiativeSortInput>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::Initiative>>
+    InitiativesQueryBuilder<'a, T>
+{
+    pub fn filter(mut self, value: InitiativeFilter) -> Self {
+        self.filter = Some(value);
+        self
+    }
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub fn sort(mut self, value: InitiativeSortInput) -> Self {
+        self.sort = Some(value);
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        if let Some(ref v) = self.filter {
+            map.insert("filter".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.sort {
+            map.insert("sort".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "Initiatives",
+            "$filter: InitiativeFilter, $before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy, $sort: [InitiativeSortInput!]",
+            "initiatives",
+            "filter: $filter, before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy, sort: $sort",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "initiatives")
+            .await
+    }
+}
 /// Query builder: All documents in the workspace.
 ///
 /// Full type: [`Document`](super::types::Document)
@@ -1257,6 +1352,40 @@ pub fn issue_labels<'a, T>(client: &'a Client) -> IssueLabelsQueryBuilder<'a, T>
         order_by: None,
         _marker: std::marker::PhantomData,
     }
+}
+/// All initiatives in the workspace.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub fn initiatives<'a, T>(client: &'a Client) -> InitiativesQueryBuilder<'a, T> {
+    InitiativesQueryBuilder {
+        client,
+        filter: None,
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        sort: None,
+        _marker: std::marker::PhantomData,
+    }
+}
+/// One specific initiative.
+///
+/// Full type: [`Initiative`](super::types::Initiative)
+pub async fn initiative<
+    T: DeserializeOwned + GraphQLFields<FullType = super::types::Initiative>,
+>(
+    client: &Client,
+    id: String,
+) -> Result<T, LinearError> {
+    let variables = serde_json::json!({ "id" : id });
+    let selection = T::selection();
+    let query = format!(
+        "query {}({}) {{ {}({}) {{ {} }} }}",
+        "Initiative", "$id: String!", "initiative", "id: $id", selection
+    );
+    client.execute::<T>(&query, variables, "initiative").await
 }
 /// All documents in the workspace.
 ///

--- a/crates/lineark/src/commands/initiatives.rs
+++ b/crates/lineark/src/commands/initiatives.rs
@@ -491,9 +491,7 @@ pub async fn run(cmd: InitiativesCmd, client: &Client, format: Format) -> anyhow
                     .find(|n| n.initiative.id.as_deref() == Some(&initiative_id))
                     .and_then(|n| n.id.clone())
                     .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "No link found between this initiative and project"
-                        )
+                        anyhow::anyhow!("No link found between this initiative and project")
                     })?;
 
                 let result = client

--- a/crates/lineark/src/commands/initiatives.rs
+++ b/crates/lineark/src/commands/initiatives.rs
@@ -1,0 +1,476 @@
+use clap::Args;
+use lineark_sdk::generated::enums::InitiativeStatus;
+use lineark_sdk::generated::inputs::{
+    InitiativeCreateInput, InitiativeToProjectCreateInput, InitiativeUpdateInput,
+};
+use lineark_sdk::generated::types::{
+    Initiative, InitiativeToProject, Project, ProjectConnection, User,
+};
+use lineark_sdk::{Client, GraphQLFields};
+use serde::{Deserialize, Serialize};
+use tabled::Tabled;
+
+use super::helpers::{resolve_initiative_id, resolve_project_id, resolve_user_id_or_me};
+use crate::output::{self, Format};
+
+/// Parse an initiative status string into the generated enum.
+fn parse_initiative_status(s: &str) -> anyhow::Result<InitiativeStatus> {
+    match s.to_lowercase().as_str() {
+        "planned" => Ok(InitiativeStatus::Planned),
+        "active" => Ok(InitiativeStatus::Active),
+        "completed" => Ok(InitiativeStatus::Completed),
+        _ => Err(anyhow::anyhow!(
+            "Invalid initiative status '{}'. Valid values: Planned, Active, Completed",
+            s
+        )),
+    }
+}
+
+/// Manage initiatives.
+#[derive(Debug, Args)]
+pub struct InitiativesCmd {
+    #[command(subcommand)]
+    pub action: InitiativesAction,
+}
+
+#[derive(Debug, clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub enum InitiativesAction {
+    /// List all initiatives.
+    ///
+    /// Examples:
+    ///   lineark initiatives list
+    ///   lineark initiatives list --limit 10
+    List {
+        /// Maximum number of initiatives to return.
+        #[arg(short = 'l', long, default_value = "50")]
+        limit: i64,
+    },
+    /// Show full details for a single initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives read "Q1 Goals"
+    ///   lineark initiatives read INITIATIVE-UUID
+    Read {
+        /// Initiative name or UUID.
+        id: String,
+    },
+    /// Create a new initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives create "Q1 Goals"
+    ///   lineark initiatives create "Q1 Goals" --status Active --owner me
+    ///   lineark initiatives create "Launch v2" --description "Ship v2 by Q2" --target-date 2026-06-30
+    Create {
+        /// Initiative name.
+        name: String,
+        /// Initiative description (markdown).
+        #[arg(short = 'd', long)]
+        description: Option<String>,
+        /// Owner: user name, display name, UUID, or `me`.
+        #[arg(long)]
+        owner: Option<String>,
+        /// Status: Planned, Active, or Completed.
+        #[arg(long)]
+        status: Option<String>,
+        /// Estimated completion date (YYYY-MM-DD).
+        #[arg(long)]
+        target_date: Option<String>,
+        /// Initiative color (hex code).
+        #[arg(long)]
+        color: Option<String>,
+        /// Initiative icon (emoji or icon name).
+        #[arg(long)]
+        icon: Option<String>,
+    },
+    /// Update an existing initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives update "Q1 Goals" --status Active
+    ///   lineark initiatives update INITIATIVE-UUID --name "Q2 Goals" --owner me
+    Update {
+        /// Initiative name or UUID.
+        id: String,
+        /// New initiative name.
+        #[arg(long)]
+        name: Option<String>,
+        /// New description (markdown).
+        #[arg(short = 'd', long)]
+        description: Option<String>,
+        /// New owner: user name, display name, UUID, or `me`.
+        #[arg(long)]
+        owner: Option<String>,
+        /// New status: Planned, Active, or Completed.
+        #[arg(long)]
+        status: Option<String>,
+        /// New estimated completion date (YYYY-MM-DD).
+        #[arg(long)]
+        target_date: Option<String>,
+    },
+    /// Archive an initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives archive "Q1 Goals"
+    ///   lineark initiatives archive INITIATIVE-UUID
+    Archive {
+        /// Initiative name or UUID.
+        id: String,
+    },
+    /// Unarchive a previously archived initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives unarchive "Q1 Goals"
+    ///   lineark initiatives unarchive INITIATIVE-UUID
+    Unarchive {
+        /// Initiative name or UUID.
+        id: String,
+    },
+    /// Delete an initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives delete "Q1 Goals"
+    ///   lineark initiatives delete INITIATIVE-UUID
+    Delete {
+        /// Initiative name or UUID.
+        id: String,
+    },
+    /// Manage project links for an initiative.
+    Projects {
+        #[command(subcommand)]
+        action: ProjectsAction,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ProjectsAction {
+    /// Link a project to an initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives projects add "Q1 Goals" --project "Mobile App UX"
+    ///   lineark initiatives projects add INITIATIVE-UUID --project PROJECT-UUID
+    Add {
+        /// Initiative name or UUID.
+        initiative: String,
+        /// Project name or UUID to link.
+        #[arg(long)]
+        project: String,
+    },
+    /// Unlink a project from an initiative.
+    ///
+    /// Examples:
+    ///   lineark initiatives projects remove "Q1 Goals" --project "Mobile App UX"
+    ///   lineark initiatives projects remove INITIATIVE-UUID --project PROJECT-UUID
+    Remove {
+        /// Initiative name or UUID.
+        initiative: String,
+        /// Project name or UUID to unlink.
+        #[arg(long)]
+        project: String,
+    },
+}
+
+// ── List row ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Tabled)]
+pub struct InitiativeRow {
+    pub id: String,
+    pub name: String,
+    pub status: String,
+    pub target_date: String,
+}
+
+/// Lean type for `initiatives list`.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Initiative)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeSummary {
+    id: Option<String>,
+    name: Option<String>,
+    status: Option<InitiativeStatus>,
+    target_date: Option<chrono::NaiveDate>,
+}
+
+// ── Read detail ──────────────────────────────────────────────────────────
+
+/// Full initiative detail for `initiatives read`.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Initiative)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeDetail {
+    id: Option<String>,
+    name: Option<String>,
+    description: Option<String>,
+    status: Option<InitiativeStatus>,
+    target_date: Option<chrono::NaiveDate>,
+    color: Option<String>,
+    icon: Option<String>,
+    url: Option<String>,
+    created_at: Option<chrono::DateTime<chrono::Utc>>,
+    updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    archived_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[graphql(nested)]
+    owner: Option<OwnerRef>,
+    #[graphql(nested)]
+    projects: Option<InitiativeProjectsConnection>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = User)]
+#[serde(rename_all = "camelCase", default)]
+struct OwnerRef {
+    id: Option<String>,
+    name: Option<String>,
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = ProjectConnection)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeProjectsConnection {
+    #[graphql(nested)]
+    nodes: Vec<InitiativeProjectRef>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Project)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeProjectRef {
+    id: Option<String>,
+    name: Option<String>,
+    slug_id: Option<String>,
+}
+
+// ── Mutation result ──────────────────────────────────────────────────────
+
+/// Lean result type for initiative mutations.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = Initiative)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeRef {
+    id: Option<String>,
+    name: Option<String>,
+    status: Option<InitiativeStatus>,
+}
+
+/// Lean result type for initiative-to-project mutations.
+#[derive(Debug, Default, Serialize, Deserialize, GraphQLFields)]
+#[graphql(full_type = InitiativeToProject)]
+#[serde(rename_all = "camelCase", default)]
+struct InitiativeToProjectRef {
+    id: Option<String>,
+}
+
+// ── Command dispatch ────────────────────────────────────────────────────
+
+pub async fn run(cmd: InitiativesCmd, client: &Client, format: Format) -> anyhow::Result<()> {
+    match cmd.action {
+        InitiativesAction::List { limit } => {
+            let conn = client
+                .initiatives::<InitiativeSummary>()
+                .first(limit)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            let rows: Vec<InitiativeRow> = conn
+                .nodes
+                .iter()
+                .map(|i| InitiativeRow {
+                    id: i.id.clone().unwrap_or_default(),
+                    name: i.name.clone().unwrap_or_default(),
+                    status: i
+                        .status
+                        .as_ref()
+                        .map(|s| format!("{:?}", s))
+                        .unwrap_or_default(),
+                    target_date: i.target_date.map(|d| d.to_string()).unwrap_or_default(),
+                })
+                .collect();
+
+            output::print_table(&rows, format);
+        }
+        InitiativesAction::Read { id } => {
+            let initiative_id = resolve_initiative_id(client, &id).await?;
+            let initiative = client
+                .initiative::<InitiativeDetail>(initiative_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            output::print_one(&initiative, format);
+        }
+        InitiativesAction::Create {
+            name,
+            description,
+            owner,
+            status,
+            target_date,
+            color,
+            icon,
+        } => {
+            let owner_id = match owner {
+                Some(ref o) => Some(resolve_user_id_or_me(client, o).await?),
+                None => None,
+            };
+
+            let parsed_status = status.map(|s| parse_initiative_status(&s)).transpose()?;
+
+            let target_date = target_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid target-date (expected YYYY-MM-DD): {}", e))?;
+
+            let input = InitiativeCreateInput {
+                name: Some(name),
+                description,
+                owner_id,
+                status: parsed_status,
+                target_date,
+                color,
+                icon,
+                ..Default::default()
+            };
+
+            let initiative = client
+                .initiative_create::<InitiativeRef>(input)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&initiative, format);
+        }
+        InitiativesAction::Update {
+            id,
+            name,
+            description,
+            owner,
+            status,
+            target_date,
+        } => {
+            if name.is_none()
+                && description.is_none()
+                && owner.is_none()
+                && status.is_none()
+                && target_date.is_none()
+            {
+                return Err(anyhow::anyhow!(
+                    "No update fields provided. Use --name, --description, --owner, --status, or --target-date."
+                ));
+            }
+
+            let initiative_id = resolve_initiative_id(client, &id).await?;
+
+            let owner_id = match owner {
+                Some(ref o) => Some(resolve_user_id_or_me(client, o).await?),
+                None => None,
+            };
+
+            let parsed_status = status.map(|s| parse_initiative_status(&s)).transpose()?;
+
+            let target_date = target_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid target-date (expected YYYY-MM-DD): {}", e))?;
+
+            let input = InitiativeUpdateInput {
+                name,
+                description,
+                owner_id,
+                status: parsed_status,
+                target_date,
+                ..Default::default()
+            };
+
+            let initiative = client
+                .initiative_update::<InitiativeRef>(input, initiative_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&initiative, format);
+        }
+        InitiativesAction::Archive { id } => {
+            let initiative_id = resolve_initiative_id(client, &id).await?;
+
+            let initiative = client
+                .initiative_archive::<InitiativeRef>(initiative_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&initiative, format);
+        }
+        InitiativesAction::Unarchive { id } => {
+            let initiative_id = resolve_initiative_id(client, &id).await?;
+
+            let initiative = client
+                .initiative_unarchive::<InitiativeRef>(initiative_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&initiative, format);
+        }
+        InitiativesAction::Delete { id } => {
+            let initiative_id = resolve_initiative_id(client, &id).await?;
+
+            let result = client
+                .initiative_delete(initiative_id)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&result, format);
+        }
+        InitiativesAction::Projects { action } => match action {
+            ProjectsAction::Add {
+                initiative,
+                project,
+            } => {
+                let initiative_id = resolve_initiative_id(client, &initiative).await?;
+                let project_id = resolve_project_id(client, &project).await?;
+
+                let input = InitiativeToProjectCreateInput {
+                    initiative_id: Some(initiative_id),
+                    project_id: Some(project_id),
+                    ..Default::default()
+                };
+
+                let join = client
+                    .initiative_to_project_create::<InitiativeToProjectRef>(input)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+                output::print_one(&join, format);
+            }
+            ProjectsAction::Remove {
+                initiative,
+                project,
+            } => {
+                let initiative_id = resolve_initiative_id(client, &initiative).await?;
+                let project_id = resolve_project_id(client, &project).await?;
+
+                // To delete the link we need the InitiativeToProject join entity ID.
+                // The Linear API only returns this from the create mutation; there is
+                // no standalone query for join entities. We use a create-then-delete
+                // pattern: creating a duplicate link returns the existing join entity
+                // (idempotent), giving us its ID, which we then delete.
+                let input = InitiativeToProjectCreateInput {
+                    initiative_id: Some(initiative_id),
+                    project_id: Some(project_id),
+                    ..Default::default()
+                };
+
+                let join = client
+                    .initiative_to_project_create::<InitiativeToProjectRef>(input)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+                let join_id = join.id.ok_or_else(|| {
+                    anyhow::anyhow!("Failed to resolve initiative-to-project link")
+                })?;
+
+                let result = client
+                    .initiative_to_project_delete(join_id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+                output::print_one(&result, format);
+            }
+        },
+    }
+    Ok(())
+}

--- a/crates/lineark/src/commands/mod.rs
+++ b/crates/lineark/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod cycles;
 pub mod documents;
 pub mod embeds;
 pub mod helpers;
+pub mod initiatives;
 pub mod issues;
 pub mod labels;
 pub mod milestones;

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -104,6 +104,23 @@ COMMANDS:
     [--target-date DATE] [--description TEXT]
   lineark project-milestones delete <ID>           Delete a milestone
     [--project NAME-OR-ID]
+  lineark initiatives list [-l N]                  List all initiatives
+  lineark initiatives read <NAME-OR-ID>            Full initiative detail (owner, projects, dates)
+  lineark initiatives create <NAME>                Create an initiative
+    [--description TEXT] [--owner NAME-OR-ID|me]   Description, initiative owner
+    [--status Planned|Active|Completed]            Status
+    [--target-date DATE] [--color HEX] [--icon IC] Target date, color, icon
+  lineark initiatives update <NAME-OR-ID>          Update an initiative
+    [--name TEXT] [--description TEXT]             Name, description
+    [--owner NAME-OR-ID|me] [--status STATUS]      Owner, status
+    [--target-date DATE]                           Target date
+  lineark initiatives archive <NAME-OR-ID>         Archive an initiative
+  lineark initiatives unarchive <NAME-OR-ID>       Unarchive an initiative
+  lineark initiatives delete <NAME-OR-ID>          Delete an initiative
+  lineark initiatives projects add <INIT>          Link a project to an initiative
+    --project NAME-OR-ID
+  lineark initiatives projects remove <INIT>       Unlink a project from an initiative
+    --project NAME-OR-ID
   lineark embeds upload <FILE> [--public]          Upload file to Linear, returns asset URL
                                                    Embed as markdown [name](url) in issues,
                                                    comments, or documents

--- a/crates/lineark/src/main.rs
+++ b/crates/lineark/src/main.rs
@@ -31,6 +31,8 @@ enum Command {
     Users(commands::users::UsersCmd),
     /// Manage projects.
     Projects(commands::projects::ProjectsCmd),
+    /// Manage initiatives.
+    Initiatives(commands::initiatives::InitiativesCmd),
     /// Manage issue labels.
     Labels(commands::labels::LabelsCmd),
     /// Manage cycles.
@@ -115,6 +117,7 @@ async fn main() {
         Command::Teams(cmd) => commands::teams::run(cmd, &client, format).await,
         Command::Users(cmd) => commands::users::run(cmd, &client, format).await,
         Command::Projects(cmd) => commands::projects::run(cmd, &client, format).await,
+        Command::Initiatives(cmd) => commands::initiatives::run(cmd, &client, format).await,
         Command::Labels(cmd) => commands::labels::run(cmd, &client, format).await,
         Command::Cycles(cmd) => commands::cycles::run(cmd, &client, format).await,
         Command::Issues(cmd) => commands::issues::run(cmd, &client, format).await,

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -887,3 +887,74 @@ fn usage_includes_comments_delete() {
         .success()
         .stdout(predicate::str::contains("comments delete"));
 }
+
+// ── Initiatives ──────────────────────────────────────────────────────────────
+
+#[test]
+fn initiatives_help_shows_subcommands() {
+    lineark()
+        .args(["initiatives", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("read"))
+        .stdout(predicate::str::contains("create"))
+        .stdout(predicate::str::contains("update"))
+        .stdout(predicate::str::contains("archive"))
+        .stdout(predicate::str::contains("unarchive"))
+        .stdout(predicate::str::contains("delete"))
+        .stdout(predicate::str::contains("projects"));
+}
+
+#[test]
+fn initiatives_create_help_shows_flags() {
+    lineark()
+        .args(["initiatives", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--description"))
+        .stdout(predicate::str::contains("--owner"))
+        .stdout(predicate::str::contains("--status"));
+}
+
+#[test]
+fn initiatives_update_no_flags_prints_error() {
+    lineark()
+        .args([
+            "--api-token",
+            "fake-token",
+            "initiatives",
+            "update",
+            "some-uuid",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No update fields provided"));
+}
+
+#[test]
+fn initiatives_projects_add_help_shows_flags() {
+    lineark()
+        .args(["initiatives", "projects", "add", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--project"))
+        .stdout(predicate::str::contains("<INITIATIVE>"));
+}
+
+#[test]
+fn usage_includes_initiatives_commands() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("initiatives list"))
+        .stdout(predicate::str::contains("initiatives read"))
+        .stdout(predicate::str::contains("initiatives create"))
+        .stdout(predicate::str::contains("initiatives update"))
+        .stdout(predicate::str::contains("initiatives archive"))
+        .stdout(predicate::str::contains("initiatives unarchive"))
+        .stdout(predicate::str::contains("initiatives delete"))
+        .stdout(predicate::str::contains("initiatives projects add"))
+        .stdout(predicate::str::contains("initiatives projects remove"));
+}

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -22,6 +22,10 @@ issueRelation = true
 projectMilestones = true
 projectMilestone = true
 
+# Phase 4 — Initiatives
+initiatives = true
+initiative = true
+
 [mutations]
 # Phase 2 — Core writes
 issueCreate = true
@@ -53,3 +57,12 @@ teamUpdate = true
 teamDelete = true
 teamMembershipCreate = true
 teamMembershipDelete = true
+
+# Phase 4 — Initiatives
+initiativeCreate = true
+initiativeUpdate = true
+initiativeArchive = true
+initiativeUnarchive = true
+initiativeDelete = true
+initiativeToProjectCreate = true
+initiativeToProjectDelete = true


### PR DESCRIPTION
## Summary
- Add new top-level `initiatives` command with list, read, create, update, archive, unarchive, and delete subcommands
- Add `initiatives projects add` and `initiatives projects remove` for linking/unlinking projects
- Add `resolve_initiative_id()` helper for name-to-UUID resolution
- Generate `initiatives`, `initiative` queries and 7 mutations via codegen
- Include offline tests (help, validation) and online tests (CRUD lifecycle, archive/unarchive, project linking)

## Test plan
- [x] `cargo build --workspace` compiles
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` passes
- [x] Offline tests pass (5 new)
- [x] SDK online tests pass (`initiative_create_update_and_delete`, `initiative_to_project_create_and_delete`)
- [x] CLI online tests pass (`initiatives_create_update_and_delete`, `initiatives_archive_and_unarchive`, `initiatives_projects_add_and_remove`)

> **Note:** Online tests depend on #105 (configurable test team env var) for reliable execution.