### PR TITLE
fix: patch lineark-test-utils version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           sed -i "s/^version = \"0.0.0\"/version = \"${VERSION}\"/" Cargo.toml
           sed -i "s/lineark-derive = { path = \"..\/lineark-derive\", version = \"0.0.0\" }/lineark-derive = { path = \"..\/lineark-derive\", version = \"${VERSION}\" }/" crates/lineark-sdk/Cargo.toml
           sed -i "s/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"0.0.0\" }/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"${VERSION}\" }/" crates/lineark/Cargo.toml
+          sed -i "s/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"0.0.0\" }/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"${VERSION}\" }/" crates/lineark-test-utils/Cargo.toml
           cargo update --workspace
 
       - name: Publish lineark-derive
@@ -132,6 +133,7 @@ jobs:
           sed -i'' -e "s/^version = \"0.0.0\"/version = \"${VERSION}\"/" Cargo.toml
           sed -i'' -e "s/lineark-derive = { path = \"..\/lineark-derive\", version = \"0.0.0\" }/lineark-derive = { path = \"..\/lineark-derive\", version = \"${VERSION}\" }/" crates/lineark-sdk/Cargo.toml
           sed -i'' -e "s/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"0.0.0\" }/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"${VERSION}\" }/" crates/lineark/Cargo.toml
+          sed -i'' -e "s/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"0.0.0\" }/lineark-sdk = { path = \"..\/lineark-sdk\", version = \"${VERSION}\" }/" crates/lineark-test-utils/Cargo.toml
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }} -p lineark --features binary-release


### PR DESCRIPTION
## Summary

- The v2.0.0 release failed because the release workflow's version patching step didn't cover `crates/lineark-test-utils/Cargo.toml`, which has `lineark-sdk = { path = "../lineark-sdk", version = "0.0.0" }`
- Cargo resolves the full workspace (including `lineark-test-utils`) and fails with `failed to select a version for the requirement lineark-sdk = "^0.0.0"` since `0.0.0` doesn't exist on crates.io
- Added the missing `sed` command in both the `publish` and `build` jobs

## Test plan

- [ ] Merge this PR, delete the v2.0.0 tag/release, and recreate it to trigger a new release workflow run