### PR TITLE
fix: wrap SDK create calls in online tests with retry_create

### DIFF
--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -2272,7 +2272,11 @@ mod online {
                 team_ids: Some(vec![team_id]),
                 ..Default::default()
             };
-            client.project_create::<Project>(None, input).await.unwrap()
+            retry_create(|| {
+                let input = input.clone();
+                async { client.project_create::<Project>(None, input).await }
+            })
+            .await
         });
         let project_id = project.id.as_ref().unwrap().to_string();
         let _project_guard = ProjectGuard {
@@ -4050,7 +4054,11 @@ mod online {
                 priority: Some(4),
                 ..Default::default()
             };
-            let entity = client.issue_create::<Issue>(input).await.unwrap();
+            let entity = retry_create(|| {
+                let input = input.clone();
+                async { client.issue_create::<Issue>(input).await }
+            })
+            .await;
             let issue_id = entity.id.clone().unwrap();
             let branch_name = entity
                 .branch_name


### PR DESCRIPTION
## Summary

- Wrap 2 bare `.unwrap()` SDK create calls in CLI online tests with `retry_create` to handle Linear API eventual consistency
- `project_create` in `project_milestones_full_crud` — this was causing intermittent CI failures with "conflict on insert of Project" / "already exists"
- `issue_create` in the find-branch test — same pattern, same risk

All other create calls in the file already used `retry_create`. The SDK online tests (`crates/lineark-sdk/tests/online.rs`) consistently use it everywhere — these 2 were the only stragglers.

## Test plan

- [x] CI online tests pass without the intermittent "conflict on insert" failure