### PR TITLE
docs: move AI agent setup into quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/flipbit03/lineark/main/install.sh |
 
 Or via cargo: `cargo install lineark`
 
-To update to the latest version:
-
-```sh
-lineark self update
-```
+To update to the latest version: `lineark self update`
 
 ### Set up your AI agent
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,7 @@ echo "lin_api_..." > ~/.linear_api_token_work
 lineark --profile work whoami
 ```
 
-### Use it
-
-```sh
-lineark whoami                              # check your identity
-lineark issues list --team ENG --mine       # my issues on the ENG team
-lineark issues search "auth bug" -l 5       # full-text search
-lineark issues create "Fix login" --team ENG -p 2 --assignee "Jane"
-lineark issues update ENG-42 -s "In Progress"
-```
-
-Output auto-detects format: human-readable tables in a terminal, JSON when piped. Override with `--format json`.
+That's it! Your agent is ready to use lineark.
 
 ## What it can do
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ To update to the latest version:
 lineark self update
 ```
 
+### Set up your AI agent
+
+Add these lines to your agent's context file (`CLAUDE.md`, `.cursorrules`, system prompt, etc.):
+
+```
+We track our tickets and projects in Linear (https://linear.app), a project management tool.
+We use the `lineark` CLI tool for communicating with Linear. Use your Bash tool to call the
+`lineark` executable. Run `lineark usage` to see usage information.
+```
+
+Your agent discovers all commands at runtime via `lineark usage` — no tool schemas, no function definitions, no context bloat.
+
+> **Not using an AI agent?** Skip this step — lineark works great as a standalone CLI too.
+
 ### Authenticate
 
 Create a [Linear Personal API key](https://linear.app/settings/account/security) and save it:
@@ -60,18 +74,6 @@ lineark issues update ENG-42 -s "In Progress"
 ```
 
 Output auto-detects format: human-readable tables in a terminal, JSON when piped. Override with `--format json`.
-
-## Set up your AI agent
-
-Add three lines to your LLM's context (`CLAUDE.md`, `.cursorrules`, system prompt, etc.):
-
-```
-We track our tickets and projects in Linear (https://linear.app), a project management tool.
-We use the `lineark` CLI tool for communicating with Linear. Use your Bash tool to call the
-`lineark` executable. Run `lineark usage` to see usage information.
-```
-
-That's it. Your agent discovers all commands at runtime by running `lineark usage`: no tool schemas, no function definitions, no context bloat.
 
 ## What it can do
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ We use the `lineark` CLI tool for communicating with Linear. Use your Bash tool 
 
 Your agent discovers all commands at runtime via `lineark usage` — no tool schemas, no function definitions, no context bloat.
 
-> **Not using an AI agent?** Skip this step — lineark works great as a standalone CLI too.
-
 ### Authenticate
 
 Create a [Linear Personal API key](https://linear.app/settings/account/security) and save it:


### PR DESCRIPTION
## Summary

- Moved the "Set up your AI agent" section from a standalone h2 below quickstart into the quickstart flow as step 2 (Install → **Set up your AI agent** → Authenticate → Use it)
- Added a blockquote note for non-agent users to skip the step
- No content changes to the frontmatter snippet itself

Addresses feedback that people were missing the agent setup instructions because they lived outside the quickstart path.

## Test plan

- [x] Verify README renders correctly on GitHub (headings, code block, blockquote)
- [x] Confirm the agent frontmatter snippet is unchanged