### PR TITLE
feat: add projects update subcommand

### DIFF
--- a/crates/lineark-sdk/src/generated/client_impl.rs
+++ b/crates/lineark-sdk/src/generated/client_impl.rs
@@ -69,6 +69,12 @@ impl Client {
     pub fn search_issues<T>(&self, term: impl Into<String>) -> SearchIssuesQueryBuilder<'_, T> {
         crate::generated::queries::search_issues(self, term)
     }
+    /// All project statuses.
+    ///
+    /// Full type: [`ProjectStatus`](super::types::ProjectStatus)
+    pub fn project_statuses<T>(&self) -> ProjectStatusesQueryBuilder<'_, T> {
+        crate::generated::queries::project_statuses(self)
+    }
     /// All milestones for the project.
     ///
     /// Full type: [`ProjectMilestone`](super::types::ProjectMilestone)
@@ -85,6 +91,12 @@ impl Client {
         id: String,
     ) -> Result<T, LinearError> {
         crate::generated::queries::project_milestone::<T>(self, id).await
+    }
+    /// All project labels.
+    ///
+    /// Full type: [`ProjectLabel`](super::types::ProjectLabel)
+    pub fn project_labels<T>(&self) -> ProjectLabelsQueryBuilder<'_, T> {
+        crate::generated::queries::project_labels(self)
     }
     /// All issues.
     ///

--- a/crates/lineark-sdk/src/generated/queries.rs
+++ b/crates/lineark-sdk/src/generated/queries.rs
@@ -489,6 +489,85 @@ impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::IssueSearc
             .await
     }
 }
+/// Query builder: All project statuses.
+///
+/// Full type: [`ProjectStatus`](super::types::ProjectStatus)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct ProjectStatusesQueryBuilder<'a, T> {
+    client: &'a Client,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::ProjectStatus>>
+    ProjectStatusesQueryBuilder<'a, T>
+{
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "ProjectStatuses",
+            "$before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy",
+            "projectStatuses",
+            "before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "projectStatuses")
+            .await
+    }
+}
 /// Query builder: All milestones for the project.
 ///
 /// Full type: [`ProjectMilestone`](super::types::ProjectMilestone)
@@ -573,6 +652,93 @@ impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::ProjectMil
         );
         self.client
             .execute_connection::<T>(&query, variables, "projectMilestones")
+            .await
+    }
+}
+/// Query builder: All project labels.
+///
+/// Full type: [`ProjectLabel`](super::types::ProjectLabel)
+///
+/// Use setter methods to configure optional parameters, then call
+/// [`.send()`](Self::send) to execute the query.
+#[must_use]
+pub struct ProjectLabelsQueryBuilder<'a, T> {
+    client: &'a Client,
+    filter: Option<ProjectLabelFilter>,
+    before: Option<String>,
+    after: Option<String>,
+    first: Option<i64>,
+    last: Option<i64>,
+    include_archived: Option<bool>,
+    order_by: Option<PaginationOrderBy>,
+    _marker: std::marker::PhantomData<T>,
+}
+impl<'a, T: DeserializeOwned + GraphQLFields<FullType = super::types::ProjectLabel>>
+    ProjectLabelsQueryBuilder<'a, T>
+{
+    pub fn filter(mut self, value: ProjectLabelFilter) -> Self {
+        self.filter = Some(value);
+        self
+    }
+    pub fn before(mut self, value: impl Into<String>) -> Self {
+        self.before = Some(value.into());
+        self
+    }
+    pub fn after(mut self, value: impl Into<String>) -> Self {
+        self.after = Some(value.into());
+        self
+    }
+    pub fn first(mut self, value: i64) -> Self {
+        self.first = Some(value);
+        self
+    }
+    pub fn last(mut self, value: i64) -> Self {
+        self.last = Some(value);
+        self
+    }
+    pub fn include_archived(mut self, value: bool) -> Self {
+        self.include_archived = Some(value);
+        self
+    }
+    pub fn order_by(mut self, value: PaginationOrderBy) -> Self {
+        self.order_by = Some(value);
+        self
+    }
+    pub async fn send(self) -> Result<Connection<T>, LinearError> {
+        let mut map = serde_json::Map::new();
+        if let Some(ref v) = self.filter {
+            map.insert("filter".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.before {
+            map.insert("before".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.after {
+            map.insert("after".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.first {
+            map.insert("first".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.last {
+            map.insert("last".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.include_archived {
+            map.insert("includeArchived".to_string(), serde_json::json!(v));
+        }
+        if let Some(ref v) = self.order_by {
+            map.insert("orderBy".to_string(), serde_json::json!(v));
+        }
+        let variables = serde_json::Value::Object(map);
+        let selection = T::selection();
+        let query = format!(
+            "query {}({}) {{ {}({}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }}",
+            "ProjectLabels",
+            "$filter: ProjectLabelFilter, $before: String, $after: String, $first: Int, $last: Int, $includeArchived: Boolean, $orderBy: PaginationOrderBy",
+            "projectLabels",
+            "filter: $filter, before: $before, after: $after, first: $first, last: $last, includeArchived: $includeArchived, orderBy: $orderBy",
+            selection
+        );
+        self.client
+            .execute_connection::<T>(&query, variables, "projectLabels")
             .await
     }
 }
@@ -1141,6 +1307,21 @@ pub fn search_issues<'a, T>(
         _marker: std::marker::PhantomData,
     }
 }
+/// All project statuses.
+///
+/// Full type: [`ProjectStatus`](super::types::ProjectStatus)
+pub fn project_statuses<'a, T>(client: &'a Client) -> ProjectStatusesQueryBuilder<'a, T> {
+    ProjectStatusesQueryBuilder {
+        client,
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        _marker: std::marker::PhantomData,
+    }
+}
 /// All milestones for the project.
 ///
 /// Full type: [`ProjectMilestone`](super::types::ProjectMilestone)
@@ -1175,6 +1356,22 @@ pub async fn project_milestone<
     client
         .execute::<T>(&query, variables, "projectMilestone")
         .await
+}
+/// All project labels.
+///
+/// Full type: [`ProjectLabel`](super::types::ProjectLabel)
+pub fn project_labels<'a, T>(client: &'a Client) -> ProjectLabelsQueryBuilder<'a, T> {
+    ProjectLabelsQueryBuilder {
+        client,
+        filter: None,
+        before: None,
+        after: None,
+        first: None,
+        last: None,
+        include_archived: None,
+        order_by: None,
+        _marker: std::marker::PhantomData,
+    }
 }
 /// All issues.
 ///

--- a/crates/lineark/src/commands/helpers.rs
+++ b/crates/lineark/src/commands/helpers.rs
@@ -1,4 +1,6 @@
-use lineark_sdk::generated::types::{Cycle, IssueLabel, IssueSearchResult, Project, Team, User};
+use lineark_sdk::generated::types::{
+    Cycle, IssueLabel, IssueSearchResult, Project, ProjectLabel, ProjectStatus, Team, User,
+};
 use lineark_sdk::Client;
 
 /// Resolve a team key or name (e.g., "ENG" or "Engineering") to a team UUID.
@@ -408,6 +410,101 @@ pub async fn resolve_cycle_id(
         name_or_id,
         available.join(", ")
     ))
+}
+
+/// Resolve a project status name or UUID to a status UUID.
+/// If the input already looks like a UUID, return it as-is.
+/// Matches case-insensitively on `name`.
+pub async fn resolve_project_status_id(
+    client: &Client,
+    name_or_id: &str,
+) -> anyhow::Result<String> {
+    if uuid::Uuid::parse_str(name_or_id).is_ok() {
+        return Ok(name_or_id.to_string());
+    }
+    let conn = client
+        .project_statuses::<ProjectStatus>()
+        .first(250)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let matches: Vec<&ProjectStatus> = conn
+        .nodes
+        .iter()
+        .filter(|s| {
+            s.name
+                .as_deref()
+                .is_some_and(|n| n.eq_ignore_ascii_case(name_or_id))
+        })
+        .collect();
+
+    match matches.len() {
+        0 => {
+            let available: Vec<String> = conn.nodes.iter().filter_map(|s| s.name.clone()).collect();
+            Err(anyhow::anyhow!(
+                "Project status '{}' not found. Available: {}",
+                name_or_id,
+                available.join(", ")
+            ))
+        }
+        1 => Ok(matches[0].id.clone().unwrap_or_default()),
+        _ => {
+            let names: Vec<String> = matches.iter().filter_map(|s| s.name.clone()).collect();
+            Err(anyhow::anyhow!(
+                "Ambiguous project status '{}'. Matches: {}",
+                name_or_id,
+                names.join(", ")
+            ))
+        }
+    }
+}
+
+/// Resolve project label names or UUIDs to a vec of project label UUIDs.
+/// Matches case-insensitively on `name`.
+pub async fn resolve_project_label_ids(
+    client: &Client,
+    names_or_ids: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let all_uuids = names_or_ids
+        .iter()
+        .all(|s| uuid::Uuid::parse_str(s).is_ok());
+    if all_uuids {
+        return Ok(names_or_ids.to_vec());
+    }
+
+    let conn = client
+        .project_labels::<ProjectLabel>()
+        .first(250)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let mut resolved = Vec::with_capacity(names_or_ids.len());
+    for item in names_or_ids {
+        if uuid::Uuid::parse_str(item).is_ok() {
+            resolved.push(item.clone());
+        } else {
+            let found = conn.nodes.iter().find(|l| {
+                l.name
+                    .as_deref()
+                    .is_some_and(|n| n.eq_ignore_ascii_case(item))
+            });
+            match found {
+                Some(label) => resolved.push(label.id.clone().unwrap_or_default()),
+                None => {
+                    let available: Vec<String> =
+                        conn.nodes.iter().filter_map(|l| l.name.clone()).collect();
+                    return Err(anyhow::anyhow!(
+                        "Project label '{}' not found. Available: {}",
+                        item,
+                        available.join(", ")
+                    ));
+                }
+            }
+        }
+    }
+    Ok(resolved)
 }
 
 /// Parse a priority value from either a number (0-4) or a name.

--- a/crates/lineark/src/commands/projects.rs
+++ b/crates/lineark/src/commands/projects.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use lineark_sdk::generated::inputs::{ProjectCreateInput, ProjectFilter};
+use lineark_sdk::generated::inputs::{ProjectCreateInput, ProjectFilter, ProjectUpdateInput};
 use lineark_sdk::generated::types::{
     Project, ProjectStatus, Team, TeamConnection, User, UserConnection,
 };
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 
 use super::helpers::{
-    parse_priority, resolve_project_id, resolve_team_ids, resolve_user_id_or_me,
-    resolve_user_ids_or_me,
+    parse_priority, resolve_project_id, resolve_project_label_ids, resolve_project_status_id,
+    resolve_team_ids, resolve_user_id_or_me, resolve_user_ids_or_me,
 };
 use crate::output::{self, Format};
 
@@ -81,6 +81,65 @@ pub enum ProjectsAction {
         /// Project color (hex color code).
         #[arg(long)]
         color: Option<String>,
+    },
+    /// Update an existing project. Returns the updated project.
+    ///
+    /// Examples:
+    ///   lineark projects update "Mobile App UX" --description "Updated scope"
+    ///   lineark projects update PROJECT-UUID --lead me --priority high
+    ///   lineark projects update "Alpha" --status "In Progress" --target-date 2026-06-01
+    ///   lineark projects update "Alpha" --clear-lead --clear-target-date
+    Update {
+        /// Project name or UUID.
+        id: String,
+        /// New project name.
+        #[arg(long)]
+        name: Option<String>,
+        /// Project description (markdown).
+        #[arg(short = 'd', long)]
+        description: Option<String>,
+        /// Markdown content for the project.
+        #[arg(long)]
+        content: Option<String>,
+        /// Project lead: user name, display name, UUID, or `me`.
+        #[arg(long)]
+        lead: Option<String>,
+        /// Remove the project lead.
+        #[arg(long, default_value = "false", conflicts_with = "lead")]
+        clear_lead: bool,
+        /// Project members: comma-separated user names, display names, UUIDs, or `me`. Replaces the existing set.
+        #[arg(long, value_delimiter = ',')]
+        members: Option<Vec<String>>,
+        /// Team(s) to associate with (key, name, or UUID). Comma-separated. Replaces the existing set.
+        #[arg(long, value_delimiter = ',')]
+        team: Option<Vec<String>>,
+        /// Planned start date (YYYY-MM-DD).
+        #[arg(long)]
+        start_date: Option<String>,
+        /// Remove the planned start date.
+        #[arg(long, default_value = "false", conflicts_with = "start_date")]
+        clear_start_date: bool,
+        /// Planned target/completion date (YYYY-MM-DD).
+        #[arg(long)]
+        target_date: Option<String>,
+        /// Remove the planned target date.
+        #[arg(long, default_value = "false", conflicts_with = "target_date")]
+        clear_target_date: bool,
+        /// Priority: 0-4 or none, urgent, high, medium, low.
+        #[arg(short = 'p', long, value_parser = parse_priority)]
+        priority: Option<i64>,
+        /// Project status name or UUID.
+        #[arg(long)]
+        status: Option<String>,
+        /// Project icon (emoji or icon name).
+        #[arg(long)]
+        icon: Option<String>,
+        /// Project color (hex color code).
+        #[arg(long)]
+        color: Option<String>,
+        /// Comma-separated project label names or UUIDs. Replaces the existing set.
+        #[arg(long, value_delimiter = ',')]
+        labels: Option<Vec<String>>,
     },
 }
 
@@ -295,6 +354,137 @@ pub async fn run(cmd: ProjectsCmd, client: &Client, format: Format) -> anyhow::R
                 .project_create::<ProjectRef>(None, input)
                 .await
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+            output::print_one(&project, format);
+        }
+        ProjectsAction::Update {
+            id,
+            name,
+            description,
+            content,
+            lead,
+            clear_lead,
+            members,
+            team,
+            start_date,
+            clear_start_date,
+            target_date,
+            clear_target_date,
+            priority,
+            status,
+            icon,
+            color,
+            labels,
+        } => {
+            if name.is_none()
+                && description.is_none()
+                && content.is_none()
+                && lead.is_none()
+                && !clear_lead
+                && members.is_none()
+                && team.is_none()
+                && start_date.is_none()
+                && !clear_start_date
+                && target_date.is_none()
+                && !clear_target_date
+                && priority.is_none()
+                && status.is_none()
+                && icon.is_none()
+                && color.is_none()
+                && labels.is_none()
+            {
+                return Err(anyhow::anyhow!(
+                    "No update fields provided. Use --name, --description, --content, --lead, --members, --team, --start-date, --target-date, --priority, --status, --icon, --color, or --labels to specify changes."
+                ));
+            }
+
+            let project_id = resolve_project_id(client, &id).await?;
+
+            let lead_id = match lead {
+                Some(ref l) => Some(resolve_user_id_or_me(client, l).await?),
+                None => None,
+            };
+
+            let member_ids = match members {
+                Some(ref m) => Some(resolve_user_ids_or_me(client, m).await?),
+                None => None,
+            };
+
+            let team_ids = match team {
+                Some(ref t) => Some(resolve_team_ids(client, t).await?),
+                None => None,
+            };
+
+            let status_id = match status {
+                Some(ref s) => Some(resolve_project_status_id(client, s).await?),
+                None => None,
+            };
+
+            let label_ids = match labels {
+                Some(ref l) => Some(resolve_project_label_ids(client, l).await?),
+                None => None,
+            };
+
+            let start_date = start_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid start-date (expected YYYY-MM-DD): {}", e))?;
+
+            let target_date = target_date
+                .map(|d| d.parse::<chrono::NaiveDate>())
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("Invalid target-date (expected YYYY-MM-DD): {}", e))?;
+
+            let input = ProjectUpdateInput {
+                name,
+                description,
+                content,
+                lead_id,
+                member_ids,
+                team_ids,
+                start_date,
+                target_date,
+                priority,
+                status_id,
+                icon,
+                color,
+                label_ids,
+                ..Default::default()
+            };
+
+            // When --clear-* flags are used, we need to send `null` for the
+            // relevant field. ProjectUpdateInput uses skip_serializing_if so
+            // None omits the field (no-op). We serialize to Value and inject null.
+            let project = if clear_lead || clear_start_date || clear_target_date {
+                let mut input_val = serde_json::to_value(&input)?;
+                let obj = input_val.as_object_mut().unwrap();
+                if clear_lead {
+                    obj.insert("leadId".to_string(), serde_json::Value::Null);
+                }
+                if clear_start_date {
+                    obj.insert("startDate".to_string(), serde_json::Value::Null);
+                }
+                if clear_target_date {
+                    obj.insert("targetDate".to_string(), serde_json::Value::Null);
+                }
+                let variables = serde_json::json!({ "input": input_val, "id": project_id });
+                let sel = <ProjectRef as GraphQLFields>::selection();
+                let query = format!(
+                    "mutation($input: ProjectUpdateInput!, $id: String!) {{ projectUpdate(input: $input, id: $id) {{ success project {{ {sel} }} }} }}"
+                );
+                let payload: serde_json::Value = client
+                    .execute(&query, variables, "projectUpdate")
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                serde_json::from_value::<ProjectRef>(
+                    payload.get("project").cloned().unwrap_or_default(),
+                )?
+            } else {
+                client
+                    .project_update::<ProjectRef>(input, project_id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?
+            };
 
             output::print_one(&project, format);
         }

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -73,6 +73,7 @@ COMMANDS:
   lineark projects list [--led-by-me]              List all projects (with lead)
   lineark projects read <NAME-OR-ID>               Full project detail (lead, members, status, dates, teams)
   lineark projects create <NAME> --team KEY ...    Create project (--help for flags)
+  lineark projects update <NAME-OR-ID> ...         Update project (--help for flags)
   lineark labels list [--team KEY]                 List labels (group, team, parent, color)
   lineark labels create|update|delete ...          Manage labels (--help for flags)
   lineark cycles list [-l N] [--team KEY]          List cycles

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -2800,6 +2800,187 @@ mod online {
         });
     }
 
+    // ── Projects update ─────────────────────────────────────────────────────
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn projects_update_multiple_fields_and_clear_lead() {
+        let token = test_token();
+        let unique_name = format!(
+            "[test] CLI projects update {}",
+            &uuid::Uuid::new_v4().to_string()[..8]
+        );
+        let updated_name = format!("{unique_name} (renamed)");
+
+        let team = create_test_team();
+        let team_key = team.key.clone();
+
+        // Create a project with a lead and target date set.
+        let output = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "projects",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--lead",
+            "me",
+            "--description",
+            "Initial description.",
+            "--target-date",
+            "2026-12-31",
+            "--priority",
+            "3",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "projects create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let created: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        let project_id = created["id"].as_str().unwrap().to_string();
+        let _project_guard = ProjectGuard {
+            token: token.clone(),
+            id: project_id.clone(),
+        };
+
+        // Update name, description, and priority in a single call.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "projects",
+                "update",
+                &project_id,
+                "--name",
+                &updated_name,
+                "--description",
+                "Updated description.",
+                "--priority",
+                "urgent",
+            ])
+            .output()
+            .expect("failed to execute lineark");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "projects update should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let updated: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(
+            updated["name"].as_str(),
+            Some(updated_name.as_str()),
+            "name should be updated"
+        );
+
+        // Read it back and verify the description/priority also persisted.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "projects",
+                "read",
+                &project_id,
+            ])
+            .output()
+            .unwrap();
+        let detail: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("read output should parse");
+        assert_eq!(
+            detail["description"].as_str(),
+            Some("Updated description."),
+            "description should be updated"
+        );
+        assert_eq!(detail["priority"].as_i64(), Some(1), "priority should be 1");
+        assert!(
+            !detail["lead"].is_null(),
+            "lead should still be set before clear-lead"
+        );
+
+        // Clear the lead and target date.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "projects",
+                "update",
+                &project_id,
+                "--clear-lead",
+                "--clear-target-date",
+            ])
+            .output()
+            .expect("failed to execute lineark");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "projects update --clear-lead should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+
+        // Read back and verify lead/target-date are now null.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "projects",
+                "read",
+                &project_id,
+            ])
+            .output()
+            .unwrap();
+        let detail: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            detail["lead"].is_null(),
+            "lead should be null after --clear-lead, got: {}",
+            detail["lead"]
+        );
+        assert!(
+            detail["targetDate"].is_null(),
+            "targetDate should be null after --clear-target-date, got: {}",
+            detail["targetDate"]
+        );
+    }
+
+    // ── Projects update requires at least one field ─────────────────────────
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn projects_update_without_fields_fails() {
+        let token = test_token();
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "projects",
+                "update",
+                "any-id",
+            ])
+            .output()
+            .expect("failed to execute lineark");
+        assert!(
+            !output.status.success(),
+            "projects update without fields should fail"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("No update fields provided"),
+            "expected 'No update fields provided' error, got: {stderr}"
+        );
+    }
+
     // ── Issues create with --assignee me ───────────────────────────────────
 
     #[test_with::runtime_ignore_if(no_online_test_token)]

--- a/schema/operations.toml
+++ b/schema/operations.toml
@@ -22,6 +22,8 @@ issueRelations = true
 issueRelation = true
 projectMilestones = true
 projectMilestone = true
+projectStatuses = true
+projectLabels = true
 
 [mutations]
 # Phase 2 — Core writes


### PR DESCRIPTION
Closes #136.

## Summary

- Adds `lineark projects update <NAME-OR-ID>` with flags for all user-facing `ProjectUpdateInput` fields: `--name`, `-d/--description`, `--content`, `--lead`, `--members`, `--team`, `--start-date`, `--target-date`, `-p/--priority`, `--status`, `--icon`, `--color`, `--labels`.
- Adds `--clear-lead`, `--clear-start-date`, `--clear-target-date` using the JSON-null-injection pattern already used by `issues update --clear-parent`, so nullable fields can actually be cleared (rather than just omitted, which is a no-op).
- Validates that at least one field is provided before hitting the API.
- Adds `projectStatuses` and `projectLabels` to `schema/operations.toml` (regenerated SDK) — needed for the new `--status` and `--labels` resolvers.
- New helpers in `commands/helpers.rs`: `resolve_project_status_id`, `resolve_project_label_ids`.
- `lineark usage` gains one line pointing at the new command.

## Test plan
- [x] `make check` — clean
- [x] `make test` — 123 offline tests pass
- [x] `make test-online` — 67 online tests pass, including two new ones:
  - `projects_update_multiple_fields_and_clear_lead` — exercises rename + description + priority, reads back, then `--clear-lead --clear-target-date` and verifies both are null
  - `projects_update_without_fields_fails` — verifies the "no update fields provided" guard