### PR TITLE
feat: add --state as alias for --status on issues commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ There's a Claude Code command for the full workflow (fetch + codegen + fix break
 - **`lineark usage`** is the LLM entry point — a compact (<1000 tokens) command reference. Keep it small for token efficiency. Only add flags/commands here when they're important enough that an LLM should know about them upfront.
 - **`--help`** on every command/subcommand is the detailed reference. All flags, descriptions, defaults, and examples go here via clap doc comments. Commands should be fully self-discoverable via `--help`.
 - Rule of thumb: `usage` = "what can I do?", `--help` = "how exactly does this work?"
+- **Keep `usage` in sync with structural changes.** When adding or removing a command, or materially changing a flag's shape/semantics (not cosmetic tweaks, renames of hidden internals, or adding a `visible_alias`), review `crates/lineark/src/commands/usage.rs` and update it. If the "what can I do?" answer changed, `usage` must reflect it.
 
 ## PR guidelines
 

--- a/crates/lineark/src/commands/issues.rs
+++ b/crates/lineark/src/commands/issues.rs
@@ -65,7 +65,7 @@ pub enum IssuesAction {
         #[arg(long)]
         assignee: Option<String>,
         /// Filter by status names (comma-separated).
-        #[arg(long, value_delimiter = ',')]
+        #[arg(long, visible_alias = "state", value_delimiter = ',')]
         status: Option<Vec<String>>,
     },
     /// Create a new issue. Returns the created issue.
@@ -100,7 +100,7 @@ pub enum IssuesAction {
         #[arg(long)]
         parent: Option<String>,
         /// Initial status name (resolved against team's workflow states).
-        #[arg(short = 's', long)]
+        #[arg(short = 's', long, visible_alias = "state")]
         status: Option<String>,
         /// Project name or UUID.
         #[arg(long)]
@@ -153,7 +153,7 @@ pub enum IssuesAction {
         #[arg(required = true, num_args = 1..)]
         identifiers: Vec<String>,
         /// New status name (resolved against the first issue's team workflow states).
-        #[arg(short = 's', long)]
+        #[arg(short = 's', long, visible_alias = "state")]
         status: Option<String>,
         /// Priority: 0-4 or none, urgent, high, medium, low.
         #[arg(short = 'p', long, value_parser = parse_priority)]
@@ -187,7 +187,7 @@ pub enum IssuesAction {
         /// Issue identifier (e.g., ENG-123) or UUID.
         identifier: String,
         /// New status name (resolved against the issue's team workflow states).
-        #[arg(short = 's', long)]
+        #[arg(short = 's', long, visible_alias = "state")]
         status: Option<String>,
         /// Priority: 0-4 or none, urgent, high, medium, low.
         #[arg(short = 'p', long, value_parser = parse_priority)]


### PR DESCRIPTION
## Summary
- Adds `visible_alias = "state"` to the `--status` flag on `issues list`, `issues create`, `issues update`, and `issues batch-update`
- Eliminates the misleading clap "did you mean --estimate" suggestion when users (especially LLMs) reach for `--state`
- `--state` now shows in `--help` output as an explicit alias

Closes #137

## Test plan
- [x] `make check` passes (lint + doc + build)
- [x] `make test` passes (44 offline tests)
- [x] Verified `--state` appears in `lineark issues update --help` output as `[aliases: --state]`