### PR TITLE
fix(test): defeat Linear API's transient "conflict on insert" flake

### DIFF
--- a/.github/workflows/ci-online-fork.yml
+++ b/.github/workflows/ci-online-fork.yml
@@ -53,23 +53,10 @@ jobs:
 
       - name: Run online tests
         # See ci.yml comment — Linear's API has a transient cold-start
-        # failure on `*Create` mutations; wrap in 3x retry to absorb it.
-        # `continue-on-error: true` keeps a bad Linear day from blocking
-        # fork PRs; failures are still visible in the job log.
-        continue-on-error: true
-        run: |
-          for attempt in 1 2 3; do
-            echo ">>> online attempt $attempt/3"
-            if cargo test --workspace --test online -- --test-threads=1; then
-              echo ">>> online passed on attempt $attempt"
-              exit 0
-            fi
-            echo ">>> online attempt $attempt failed; cleaning workspace before retry"
-            cargo run -p lineark-test-utils --bin cleanup-test-workspace || true
-            sleep 30
-          done
-          echo ">>> online failed after 3 attempts"
-          exit 1
+        # failure on `*Create` mutations; the per-call retry helper in
+        # crates/lineark/tests/online.rs absorbs it (15 attempts with body
+        # mutation, ~9 min worst case per call).
+        run: cargo test --workspace --test online -- --test-threads=1
 
       - name: Clean test workspace (post)
         if: always()

--- a/.github/workflows/ci-online-fork.yml
+++ b/.github/workflows/ci-online-fork.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Run online tests
         # See ci.yml comment — Linear's API has a transient cold-start
         # failure on `*Create` mutations; wrap in 3x retry to absorb it.
+        # `continue-on-error: true` keeps a bad Linear day from blocking
+        # fork PRs; failures are still visible in the job log.
+        continue-on-error: true
         run: |
           for attempt in 1 2 3; do
             echo ">>> online attempt $attempt/3"

--- a/.github/workflows/ci-online-fork.yml
+++ b/.github/workflows/ci-online-fork.yml
@@ -52,7 +52,21 @@ jobs:
         run: cargo run -p lineark-test-utils --bin cleanup-test-workspace
 
       - name: Run online tests
-        run: cargo test --workspace --test online -- --test-threads=1
+        # See ci.yml comment — Linear's API has a transient cold-start
+        # failure on `*Create` mutations; wrap in 3x retry to absorb it.
+        run: |
+          for attempt in 1 2 3; do
+            echo ">>> online attempt $attempt/3"
+            if cargo test --workspace --test online -- --test-threads=1; then
+              echo ">>> online passed on attempt $attempt"
+              exit 0
+            fi
+            echo ">>> online attempt $attempt failed; cleaning workspace before retry"
+            cargo run -p lineark-test-utils --bin cleanup-test-workspace || true
+            sleep 30
+          done
+          echo ">>> online failed after 3 attempts"
+          exit 1
 
       - name: Clean test workspace (post)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,30 +109,12 @@ jobs:
       - name: Run online tests
         # Linear's API has a known transient failure mode on `*Create`
         # mutations (returns "conflict on insert" with a phantom UUID — see
-        # the helper docs in crates/lineark/tests/online.rs). The per-call
-        # retry there handles most cases, but the cold-start window is
-        # occasionally longer than its budget. Wrap the whole suite in a 3x
-        # retry with a workspace clean between attempts.
-        #
-        # `continue-on-error: true` keeps a bad Linear day from sinking the
-        # whole CI check — the job still runs and failures are visible in
-        # this log for triage, but they don't gate the PR. Revisit once
-        # Linear's API stabilizes (or move online tests to a separate
-        # non-required workflow).
-        continue-on-error: true
-        run: |
-          for attempt in 1 2 3; do
-            echo ">>> online attempt $attempt/3"
-            if cargo test --workspace --test online -- --test-threads=1; then
-              echo ">>> online passed on attempt $attempt"
-              exit 0
-            fi
-            echo ">>> online attempt $attempt failed; cleaning workspace before retry"
-            cargo run -p lineark-test-utils --bin cleanup-test-workspace || true
-            sleep 30
-          done
-          echo ">>> online failed after 3 attempts"
-          exit 1
+        # the `run_lineark_with_retry` helper docs in
+        # `crates/lineark/tests/online.rs`). That per-call helper retries up
+        # to 15 times with body mutation, persistent enough to ride out the
+        # cold-start window without needing a suite-level wrapper that would
+        # waste cycles re-running the 60+ tests that already passed.
+        run: cargo test --workspace --test online -- --test-threads=1
 
       - name: Clean test workspace (post)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,25 @@ jobs:
         run: cargo run -p lineark-test-utils --bin cleanup-test-workspace
 
       - name: Run online tests
-        run: cargo test --workspace --test online -- --test-threads=1
+        # Linear's API has a known transient failure mode on `*Create`
+        # mutations (returns "conflict on insert" with a phantom UUID — see
+        # the helper docs in crates/lineark/tests/online.rs). The per-call
+        # retry there handles most cases, but the cold-start window is
+        # occasionally longer than its budget. Wrap the whole suite in a 3x
+        # retry with a workspace clean between attempts.
+        run: |
+          for attempt in 1 2 3; do
+            echo ">>> online attempt $attempt/3"
+            if cargo test --workspace --test online -- --test-threads=1; then
+              echo ">>> online passed on attempt $attempt"
+              exit 0
+            fi
+            echo ">>> online attempt $attempt failed; cleaning workspace before retry"
+            cargo run -p lineark-test-utils --bin cleanup-test-workspace || true
+            sleep 30
+          done
+          echo ">>> online failed after 3 attempts"
+          exit 1
 
       - name: Clean test workspace (post)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,13 @@ jobs:
         # retry there handles most cases, but the cold-start window is
         # occasionally longer than its budget. Wrap the whole suite in a 3x
         # retry with a workspace clean between attempts.
+        #
+        # `continue-on-error: true` keeps a bad Linear day from sinking the
+        # whole CI check — the job still runs and failures are visible in
+        # this log for triage, but they don't gate the PR. Revisit once
+        # Linear's API stabilizes (or move online tests to a separate
+        # non-required workflow).
+        continue-on-error: true
         run: |
           for attempt in 1 2 3; do
             echo ">>> online attempt $attempt/3"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,34 @@ make test-online                         # online tests (live API, serial, needs
 
 **Online tests must run serially.** They hit the live Linear API, which has plan-level limits (e.g. max teams). Running them in parallel causes spurious failures from resource exhaustion. `make test-online` handles this automatically.
 
-**Online tests must be self-contained.** Never assume resources (projects, issues, teams, etc.) already exist in the test workspace. Each test must create the resources it needs and clean them up afterwards using RAII guards (`TeamGuard`, `IssueGuard`, `ProjectGuard`). These guards auto-delete the resource on drop, ensuring cleanup even when the test panics. Always use `create_test_team()` to create teams — it sets unique keys per team to avoid human identifier collisions in Linear's search index. Use unique names for other resources (e.g. `format!("[test] my thing {}", &uuid::Uuid::new_v4().to_string()[..8])`) to avoid conflicts from zombie resources left by previously-failed runs. Use `retry_with_backoff` when querying recently-created resources, since the Linear API is eventually consistent. Always check `output.status.success()` and include stdout/stderr in assertion messages before parsing JSON output — a bare `.unwrap()` on JSON parsing hides the real error (e.g. auth failures).
+### Writing online tests: the three pillars
+
+Linear's API has permanent, structural consistency issues — not "temporary flakiness that will go away". Treat them as part of the environment you're testing against. **Every online test must apply all three of these**, in every CRUD path it touches, or it will flake in CI:
+
+**1. Proactive cleanup.** Never assume the workspace is empty, and never leak resources between tests.
+
+- Call `create_test_team()` (from `lineark-test-utils`) for every test that needs a team. It invokes `cleanup_zombies()` once per process and assigns a fresh unique team key, dodging Linear's indexed-identifier collisions.
+- Wrap every created resource in the matching RAII guard from `lineark_test_utils::guards` (`TeamGuard`, `IssueGuard`, `ProjectGuard`, `DocumentGuard`, `LabelGuard`) *immediately* after the create returns its ID. Guards delete on drop, so cleanup happens even when a later assert panics. Never rely on explicit `.delete(...)` calls — a panic will skip them.
+- If the test creates resources through a path the guards don't yet cover (e.g. a new Linear entity type), add a new guard to `crates/lineark-test-utils/src/guards.rs` before shipping the test.
+
+**2. Unique names per attempt.** Linear's API returns phantom "conflict on insert" errors keyed on request body content, so two attempts with the same body get the same sticky conflict.
+
+- Generate a per-test random suffix: `format!("[test] <what> {}", &uuid::Uuid::new_v4().to_string()[..8])`. The `[test]` prefix is what `cleanup_workspace` looks for.
+- If a helper retries a mutation on transient failure (see pillar 3), it **must mutate the request body between attempts** — not just re-send. Our CLI helper `run_lineark_with_retry` appends a fresh `retry-<uuid6>` suffix to the `<name>` positional and returns the actually-used name so the test can look the entity up later.
+- Don't reuse fixture names across tests. Each test call site should get its own UUID-suffixed name.
+
+**3. Retries on every API call that can fail transiently.**
+
+- **Creates** (`retry_create` in `lineark-test-utils`): 3 attempts with backoff, retries on "conflict on insert" / "already exists". Use for any SDK `*_create` call. The CLI-shell variant is `run_lineark_with_retry` in `crates/lineark/tests/online.rs` (8 attempts with body mutation).
+- **Reads after a recent create** (`retry_search` / `retry_with_backoff`): Linear's search/filter indexes are eventually consistent — a freshly-created resource may not be queryable by name for several seconds. Use `retry_search` with a predicate, or `retry_with_backoff` for arbitrary checks that need time to propagate.
+- **`settle()` (5s sleep)** between a create and the subsequent assertion, when retry-with-predicate isn't applicable.
+- **CI-level belt-and-suspenders**: `.github/workflows/ci.yml` wraps the whole online suite in a 3x retry with workspace cleanup between attempts, and runs with `continue-on-error: true` so a bad Linear day doesn't gate PRs. Don't rely on this at the test level — the above per-call helpers are the real line of defense.
+
+### Other online-test rules
+
+- **Check process exit before parsing output.** For tests that shell out to `lineark`, always `assert!(output.status.success(), "<msg>\nstdout: {stdout}\nstderr: {stderr}")` **before** `serde_json::from_str`. A bare `.unwrap()` on JSON parsing hides the real error (usually auth, schema drift, or a new required field).
+- **Skip when no token.** Guard every online test with `#[test_with::runtime_ignore_if(no_online_test_token)]` so contributors without a token aren't blocked.
+- **No production tokens.** The test token must point at a dedicated test workspace. `cleanup_workspace` deletes everything with the `[test]` prefix — running against prod would be catastrophic.
 
 ## Updating the schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,17 @@ Linear's API has permanent, structural consistency issues — not "temporary fla
 
 **3. Retries on every API call that can fail transiently.**
 
-- **Creates** (`retry_create` in `lineark-test-utils`): 3 attempts with backoff, retries on "conflict on insert" / "already exists". Use for any SDK `*_create` call. The CLI-shell variant is `run_lineark_with_retry` in `crates/lineark/tests/online.rs` (8 attempts with body mutation).
+- **Creates** (`retry_create` in `lineark-test-utils`): **15 attempts** with backoffs `[0, 2, 5, 10, 20, 30, 60×9]`s (~9 min worst case), retries on "conflict on insert" / "already exists". Use for any SDK `*_create` call. The CLI-shell variant is `run_lineark_with_retry` in `crates/lineark/tests/online.rs` — same 15-attempt budget, plus body mutation (appends a fresh `retry-<uuid6>` suffix to the positional after `"create"`, gated on `[test]` prefix so UUID positionals like `comments create <uuid>` aren't corrupted).
 - **Reads after a recent create** (`retry_search` / `retry_with_backoff`): Linear's search/filter indexes are eventually consistent — a freshly-created resource may not be queryable by name for several seconds. Use `retry_search` with a predicate, or `retry_with_backoff` for arbitrary checks that need time to propagate.
 - **`settle()` (5s sleep)** between a create and the subsequent assertion, when retry-with-predicate isn't applicable.
-- **CI-level belt-and-suspenders**: `.github/workflows/ci.yml` wraps the whole online suite in a 3x retry with workspace cleanup between attempts, and runs with `continue-on-error: true` so a bad Linear day doesn't gate PRs. Don't rely on this at the test level — the above per-call helpers are the real line of defense.
+- **No suite-level retry.** CI runs the online suite single-shot. Per-call persistence inside the helpers above is the line of defense — if a test fails, it's a real regression, not a flake worth retrying. Earlier iterations had a 3x suite wrapper + `continue-on-error: true`; both removed once per-call retries became persistent enough to stand on their own.
 
 ### Other online-test rules
 
 - **Check process exit before parsing output.** For tests that shell out to `lineark`, always `assert!(output.status.success(), "<msg>\nstdout: {stdout}\nstderr: {stderr}")` **before** `serde_json::from_str`. A bare `.unwrap()` on JSON parsing hides the real error (usually auth, schema drift, or a new required field).
 - **Skip when no token.** Guard every online test with `#[test_with::runtime_ignore_if(no_online_test_token)]` so contributors without a token aren't blocked.
 - **No production tokens.** The test token must point at a dedicated test workspace. `cleanup_workspace` deletes everything with the `[test]` prefix — running against prod would be catastrophic.
+- **Multi-workspace token pool.** `~/.linear_api_token_test` (and the `LINEAR_TEST_TOKEN` GitHub secret) accept a `;`-separated pool of API tokens — one per Linear workspace. `test_token()` picks one at random per test process and pins it for the process lifetime, spreading load across workspaces (free-plan limits, trash retention). Single-token files still work unchanged. Newlines also separate; `#`-prefixed comment lines are ignored. The `cleanup-test-workspace` binary iterates every pooled workspace, not just the one drawn this run.
 
 ## Updating the schema
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,22 @@ test:
 # Run online tests against the live Linear API. Requires ~/.linear_api_token_test.
 # Cleans the test workspace before running to avoid stale resource conflicts.
 # test_with's custom harness runs tests sequentially and aborts on first panic.
+#
+# Linear's API has a known transient failure mode on `*Create` mutations
+# (returns "conflict on insert" with a UUID it just generated, with no
+# matching record server-side — confirmed by `read` returning "not found").
+# The per-call helper in tests/online.rs retries with body mutation, but the
+# cold-start window is sometimes longer than the 8-attempt budget there.
+# Wrap the whole suite in a 3x retry so a single unlucky test doesn't sink CI.
 test-online:
 	cargo run -p lineark-test-utils --bin cleanup-test-workspace
-	cargo test --workspace --test online -- --test-threads=1
+	@for attempt in 1 2 3; do \
+		echo ">>> test-online attempt $$attempt/3"; \
+		if cargo test --workspace --test online -- --test-threads=1; then \
+			echo ">>> test-online passed on attempt $$attempt"; exit 0; \
+		fi; \
+		echo ">>> test-online attempt $$attempt failed; cleaning up before retry"; \
+		cargo run -p lineark-test-utils --bin cleanup-test-workspace; \
+		sleep 30; \
+	done; \
+	echo ">>> test-online failed after 3 attempts"; exit 1

--- a/Makefile
+++ b/Makefile
@@ -30,18 +30,10 @@ test:
 # Linear's API has a known transient failure mode on `*Create` mutations
 # (returns "conflict on insert" with a UUID it just generated, with no
 # matching record server-side — confirmed by `read` returning "not found").
-# The per-call helper in tests/online.rs retries with body mutation, but the
-# cold-start window is sometimes longer than the 8-attempt budget there.
-# Wrap the whole suite in a 3x retry so a single unlucky test doesn't sink CI.
+# The per-call `run_lineark_with_retry` helper in
+# `crates/lineark/tests/online.rs` retries up to 15 times with body
+# mutation (~9 min worst case per call), persistent enough that a single
+# unlucky test no longer needs a suite-level wrapper to compensate.
 test-online:
 	cargo run -p lineark-test-utils --bin cleanup-test-workspace
-	@for attempt in 1 2 3; do \
-		echo ">>> test-online attempt $$attempt/3"; \
-		if cargo test --workspace --test online -- --test-threads=1; then \
-			echo ">>> test-online passed on attempt $$attempt"; exit 0; \
-		fi; \
-		echo ">>> test-online attempt $$attempt failed; cleaning up before retry"; \
-		cargo run -p lineark-test-utils --bin cleanup-test-workspace; \
-		sleep 30; \
-	done; \
-	echo ">>> test-online failed after 3 attempts"; exit 1
+	cargo test --workspace --test online -- --test-threads=1

--- a/crates/lineark-sdk/tests/online.rs
+++ b/crates/lineark-sdk/tests/online.rs
@@ -549,8 +549,12 @@ mod online {
         let team_id = team.id.clone();
 
         // Create an issue.
+        let title = format!(
+            "[test] SDK issue_create_and_delete {}",
+            &uuid::Uuid::new_v4().to_string()[..8]
+        );
         let input = IssueCreateInput {
-            title: Some("[test] SDK issue_create_and_delete".to_string()).into(),
+            title: Some(title).into(),
             team_id,
             description: Some("Automated test — will be deleted immediately.".to_string()).into(),
             priority: Some(4).into(), // Low
@@ -585,8 +589,9 @@ mod online {
         let team = create_test_team(&client).await;
         let team_id = team.id.clone();
 
+        let suffix = &uuid::Uuid::new_v4().to_string()[..8];
         let input = IssueCreateInput {
-            title: Some("[test] SDK issue_update".to_string()).into(),
+            title: Some(format!("[test] SDK issue_update {suffix}")).into(),
             team_id,
             priority: Some(4).into(),
             ..Default::default()
@@ -604,7 +609,7 @@ mod online {
 
         // Update the issue.
         let update_input = IssueUpdateInput {
-            title: Some("[test] SDK issue_update — updated".to_string()).into(),
+            title: Some(format!("[test] SDK issue_update — updated {suffix}")).into(),
             priority: Some(3).into(), // Medium
             ..Default::default()
         };
@@ -633,7 +638,11 @@ mod online {
         let team_id = team.id.clone();
 
         let input = IssueCreateInput {
-            title: Some("[test] SDK issue_archive_and_unarchive".to_string()).into(),
+            title: Some(format!(
+                "[test] SDK issue_archive_and_unarchive {}",
+                &uuid::Uuid::new_v4().to_string()[..8]
+            ))
+            .into(),
             team_id,
             priority: Some(4).into(),
             ..Default::default()
@@ -679,7 +688,11 @@ mod online {
         let team_id = team.id.clone();
 
         let issue_input = IssueCreateInput {
-            title: Some("[test] SDK comment_create".to_string()).into(),
+            title: Some(format!(
+                "[test] SDK comment_create {}",
+                &uuid::Uuid::new_v4().to_string()[..8]
+            ))
+            .into(),
             team_id,
             priority: Some(4).into(),
             ..Default::default()
@@ -744,8 +757,10 @@ mod online {
         let team_id = team.id.clone();
 
         // Create a document.
+        let suffix = &uuid::Uuid::new_v4().to_string()[..8];
+        let title = format!("[test] SDK document_create_update_and_delete {suffix}");
         let input = DocumentCreateInput {
-            title: "[test] SDK document_create_update_and_delete".to_string(),
+            title: title.clone(),
             content: Some("Automated test document content.".to_string()).into(),
             team_id: Some(team_id).into(),
             ..Default::default()
@@ -765,14 +780,11 @@ mod online {
         // Read the document by ID.
         let fetched = client.document::<Document>(doc_id.clone()).await.unwrap();
         assert_eq!(fetched.id, Some(doc_id.clone()));
-        assert_eq!(
-            fetched.title,
-            Some("[test] SDK document_create_update_and_delete".to_string())
-        );
+        assert_eq!(fetched.title, Some(title));
 
         // Update the document.
         let update_input = DocumentUpdateInput {
-            title: Some("[test] SDK document — updated".to_string()).into(),
+            title: Some(format!("[test] SDK document — updated {suffix}")).into(),
             content: Some("Updated content.".to_string()).into(),
             ..Default::default()
         };
@@ -813,8 +825,9 @@ mod online {
         let team_id = team.id.clone();
 
         // Create two issues to relate.
+        let suffix = &uuid::Uuid::new_v4().to_string()[..8];
         let input_a = IssueCreateInput {
-            title: Some("[test] relation issue A".to_string()).into(),
+            title: Some(format!("[test] relation issue A {suffix}")).into(),
             team_id: team_id.clone(),
             priority: Some(4).into(),
             ..Default::default()
@@ -831,7 +844,7 @@ mod online {
         };
 
         let input_b = IssueCreateInput {
-            title: Some("[test] relation issue B".to_string()).into(),
+            title: Some(format!("[test] relation issue B {suffix}")).into(),
             team_id,
             priority: Some(4).into(),
             ..Default::default()

--- a/crates/lineark-test-utils/src/bin/cleanup.rs
+++ b/crates/lineark-test-utils/src/bin/cleanup.rs
@@ -1,9 +1,36 @@
+//! Housekeeping binary: clean every pooled test workspace.
+//!
+//! Iterates every token from `~/.linear_api_token_test` (the same `;`/newline
+//! pool consumed by `test_token()`), creating a fresh client per workspace
+//! and running `cleanup_workspace` against each. Failures on one workspace
+//! don't abort the others — we want best-effort cleanup of the entire pool
+//! before any test process picks one at random.
+//!
+//! This is what the CI `Clean test workspace` step calls. Without it, only
+//! the workspace the test process happens to draw gets cleaned (via
+//! `cleanup_zombies()` inside the test binary), and the others silently
+//! accumulate trash over time.
+
 use lineark_sdk::Client;
-use lineark_test_utils::{cleanup_workspace, test_token};
+use lineark_test_utils::{all_test_tokens, cleanup_workspace};
 
 #[tokio::main]
 async fn main() {
-    let client = Client::from_token(test_token()).expect("failed to create test client");
-    cleanup_workspace(&client).await;
-    eprintln!("cleanup: done");
+    let tokens = all_test_tokens();
+    let total = tokens.len();
+    eprintln!("cleanup: starting sweep of {total} pooled workspace(s)");
+
+    for (idx, token) in tokens.into_iter().enumerate() {
+        let n = idx + 1;
+        // Last 6 chars only — same triage tag as `test_token` logs, so a
+        // failure here lines up visually with what the test process used.
+        let tag = token.get(token.len().saturating_sub(6)..).unwrap_or("?");
+        eprintln!("cleanup: workspace {n}/{total} (token …{tag})");
+        match Client::from_token(token) {
+            Ok(client) => cleanup_workspace(&client).await,
+            Err(e) => eprintln!("cleanup: workspace {n}/{total} client init failed: {e}"),
+        }
+    }
+
+    eprintln!("cleanup: done ({total} workspace(s))");
 }

--- a/crates/lineark-test-utils/src/cleanup.rs
+++ b/crates/lineark-test-utils/src/cleanup.rs
@@ -9,6 +9,14 @@ use crate::test_token;
 /// for CI. Free plans have hard resource limits (e.g. max 1 team), so we must
 /// ensure a clean slate before tests run.
 ///
+/// **Always queries with `include_archived(true)`** so that soft-deleted /
+/// trashed resources from previous runs are also enumerated. Linear's
+/// `*_delete` mutations on projects only trash the entity (no permanent
+/// delete via the API), and the trashed rows still occupy plan-level
+/// resource slots — which empirically causes follow-up `*Create`
+/// mutations to fail with phantom "conflict on insert" errors. Skipping
+/// archived rows in the query was the bug that left those zombies behind.
+///
 /// Teams are only deleted if `[test]`-prefixed (the default workspace team must
 /// stay — Linear won't actually delete it and the free plan only allows one).
 /// All other resource types are deleted unconditionally.
@@ -18,7 +26,13 @@ use crate::test_token;
 pub async fn cleanup_workspace(client: &Client) {
     // Issues first — they belong to teams, and deleting a team may fail if
     // issues still reference it.
-    if let Ok(conn) = client.issues::<Issue>().first(250).send().await {
+    if let Ok(conn) = client
+        .issues::<Issue>()
+        .first(250)
+        .include_archived(true)
+        .send()
+        .await
+    {
         for issue in &conn.nodes {
             if let Some(id) = &issue.id {
                 let title = issue.title.as_deref().unwrap_or("<untitled>");
@@ -29,7 +43,13 @@ pub async fn cleanup_workspace(client: &Client) {
     }
 
     // Documents before projects.
-    if let Ok(conn) = client.documents::<Document>().first(250).send().await {
+    if let Ok(conn) = client
+        .documents::<Document>()
+        .first(250)
+        .include_archived(true)
+        .send()
+        .await
+    {
         for doc in &conn.nodes {
             if let Some(id) = &doc.id {
                 let title = doc.title.as_deref().unwrap_or("<untitled>");
@@ -39,8 +59,16 @@ pub async fn cleanup_workspace(client: &Client) {
         }
     }
 
-    // Projects.
-    if let Ok(conn) = client.projects::<Project>().first(250).send().await {
+    // Projects — must include archived/trashed so prior runs' zombies get
+    // cleaned up. Linear's `projectDelete` only trashes; trashed projects
+    // appear here on subsequent runs and we re-call delete (idempotent).
+    if let Ok(conn) = client
+        .projects::<Project>()
+        .first(250)
+        .include_archived(true)
+        .send()
+        .await
+    {
         for project in &conn.nodes {
             if let Some(id) = &project.id {
                 let name = project.name.as_deref().unwrap_or("<unnamed>");
@@ -51,7 +79,13 @@ pub async fn cleanup_workspace(client: &Client) {
     }
 
     // Issue labels (only custom ones — built-in labels will fail silently).
-    if let Ok(conn) = client.issue_labels::<IssueLabel>().first(250).send().await {
+    if let Ok(conn) = client
+        .issue_labels::<IssueLabel>()
+        .first(250)
+        .include_archived(true)
+        .send()
+        .await
+    {
         for label in &conn.nodes {
             if let Some(id) = &label.id {
                 let name = label.name.as_deref().unwrap_or("<unnamed>");
@@ -63,7 +97,13 @@ pub async fn cleanup_workspace(client: &Client) {
 
     // Teams — only [test]-prefixed. The default workspace team must stay
     // (free plan allows max 1 team; Linear won't actually delete it).
-    if let Ok(conn) = client.teams::<Team>().first(250).send().await {
+    if let Ok(conn) = client
+        .teams::<Team>()
+        .first(250)
+        .include_archived(true)
+        .send()
+        .await
+    {
         for team in &conn.nodes {
             if let (Some(id), Some(name)) = (&team.id, &team.name) {
                 if name.starts_with("[test]") {

--- a/crates/lineark-test-utils/src/lib.rs
+++ b/crates/lineark-test-utils/src/lib.rs
@@ -13,4 +13,4 @@ pub use cleanup::{cleanup_workspace, cleanup_zombies};
 pub use guards::*;
 pub use retry::{retry_create, retry_search, retry_with_backoff, settle};
 pub use team::{create_test_team, TestTeam};
-pub use token::{no_online_test_token, test_token};
+pub use token::{all_test_tokens, no_online_test_token, test_token};

--- a/crates/lineark-test-utils/src/retry.rs
+++ b/crates/lineark-test-utils/src/retry.rs
@@ -42,9 +42,7 @@ where
                     panic!("create failed with non-transient error: {msg}");
                 }
                 last_msg = msg;
-                eprintln!(
-                    "retry_create: attempt {attempt} failed with transient error, retrying"
-                );
+                eprintln!("retry_create: attempt {attempt} failed with transient error, retrying");
             }
         }
     }

--- a/crates/lineark-test-utils/src/retry.rs
+++ b/crates/lineark-test-utils/src/retry.rs
@@ -6,16 +6,33 @@ pub async fn settle() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 }
 
-/// Retry a create operation up to 3 times with backoff on transient errors.
-/// Retries on "conflict on insert" or "already exists" errors from the Linear API.
+/// Retry a create operation persistently on Linear's transient "conflict on
+/// insert" / "already exists" errors.
+///
+/// Linear's API has a known cold-start failure mode where freshly-generated
+/// UUIDs spuriously collide for the first several attempts of a fresh test
+/// process, then abruptly start working. Per-test persistence (rather than
+/// a suite-level retry that would waste cycles re-running passing tests)
+/// is the right answer.
+///
+/// 15 attempts with backoffs `[0, 2, 5, 10, 20, 30, 60, 60, 60, 60, 60, 60,
+/// 60, 60, 60]` seconds (~9 min worst case). Mirrors the CLI helper
+/// `run_lineark_with_retry` in `crates/lineark/tests/online.rs`.
+///
+/// Note: unlike the CLI helper, this can't mutate the request body between
+/// attempts (the closure captures input by reference). Callers that
+/// generate input bodies inside the closure can vary the body themselves
+/// for finer control; otherwise we're relying on persistence alone.
 pub async fn retry_create<T, F, Fut>(mut f: F) -> T
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, lineark_sdk::LinearError>>,
 {
-    for attempt in 0..3u32 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(1u64 << attempt)).await;
+    const BACKOFFS: &[u64] = &[0, 2, 5, 10, 20, 30, 60, 60, 60, 60, 60, 60, 60, 60, 60];
+    let mut last_msg = String::new();
+    for (attempt, &wait) in BACKOFFS.iter().enumerate() {
+        if wait > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
         }
         match f().await {
             Ok(val) => return val,
@@ -24,16 +41,14 @@ where
                 if !msg.contains("conflict on insert") && !msg.contains("already exists") {
                     panic!("create failed with non-transient error: {msg}");
                 }
-                if attempt == 2 {
-                    panic!("create failed after 3 retries: {msg}");
-                }
+                last_msg = msg;
                 eprintln!(
-                    "retry_create: attempt {attempt} failed with transient error, retrying: {msg}"
+                    "retry_create: attempt {attempt} failed with transient error, retrying"
                 );
             }
         }
     }
-    unreachable!()
+    panic!("create failed after {} retries: {last_msg}", BACKOFFS.len());
 }
 
 /// Retry a search operation with generous backoff for Linear's eventually-consistent search index.

--- a/crates/lineark-test-utils/src/token.rs
+++ b/crates/lineark-test-utils/src/token.rs
@@ -42,6 +42,22 @@ pub fn test_token() -> String {
     CHOSEN.get_or_init(load_and_pick).clone()
 }
 
+/// Read all tokens from `~/.linear_api_token_test`. Used by housekeeping
+/// jobs (e.g. the `cleanup-test-workspace` binary) that need to operate
+/// on every pooled workspace, not just the random one this process drew.
+pub fn all_test_tokens() -> Vec<String> {
+    let path = token_path().expect("could not determine home directory");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()));
+    let tokens: Vec<String> = parse_tokens(&raw).into_iter().map(String::from).collect();
+    assert!(
+        !tokens.is_empty(),
+        "no API tokens found in {} — file should contain one or more `;`-separated tokens",
+        path.display()
+    );
+    tokens
+}
+
 fn load_and_pick() -> String {
     let path = token_path().expect("could not determine home directory");
     let raw = std::fs::read_to_string(&path)

--- a/crates/lineark-test-utils/src/token.rs
+++ b/crates/lineark-test-utils/src/token.rs
@@ -1,19 +1,157 @@
+//! Test API token loading with optional multi-workspace pooling.
+//!
+//! `~/.linear_api_token_test` (and the `LINEAR_TEST_TOKEN` GitHub secret)
+//! holds one or more Linear API tokens, separated by `;` (any whitespace
+//! around separators is trimmed; an empty trailing token is ignored, so a
+//! trailing `;` is harmless). One token per line is also accepted, which
+//! makes a single-token file (the original format) work unchanged.
+//!
+//! When multiple tokens are present, [`test_token`] picks one at random
+//! per test process and returns the same one for the lifetime of that
+//! process (resources created by one test reference the same workspace
+//! the next test runs against). Across many test runs the load is
+//! distributed roughly uniformly, which spreads pressure on Linear's
+//! free-plan resource limits and trash-retention quirks across N
+//! workspaces instead of hammering one.
+
+use std::sync::OnceLock;
+
+const TOKEN_FILE: &str = ".linear_api_token_test";
+
+fn token_path() -> Option<std::path::PathBuf> {
+    home::home_dir().map(|h| h.join(TOKEN_FILE))
+}
+
 /// Returns `Some(reason)` if the test token file is missing, `None` if present.
 /// Used with `test_with::runtime_ignore_if` to skip online tests gracefully.
 pub fn no_online_test_token() -> Option<String> {
-    let path = home::home_dir()?.join(".linear_api_token_test");
+    let path = token_path()?;
     if path.exists() {
         None
     } else {
-        Some("~/.linear_api_token_test not found".to_string())
+        Some(format!("~/{TOKEN_FILE} not found"))
     }
 }
 
-/// Read the test API token from `~/.linear_api_token_test`.
+/// Read the test API token from `~/.linear_api_token_test`. When the file
+/// holds multiple `;`-separated tokens, picks one at random per process.
+/// The choice is cached so every test in the same process uses the same
+/// workspace.
 pub fn test_token() -> String {
-    let path = home::home_dir()
-        .expect("could not determine home directory")
-        .join(".linear_api_token_test");
-    lineark_sdk::auth::token_from_file(&path)
-        .unwrap_or_else(|e| panic!("could not read test token: {}", e))
+    static CHOSEN: OnceLock<String> = OnceLock::new();
+    CHOSEN.get_or_init(load_and_pick).clone()
+}
+
+fn load_and_pick() -> String {
+    let path = token_path().expect("could not determine home directory");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()));
+    let tokens = parse_tokens(&raw);
+    assert!(
+        !tokens.is_empty(),
+        "no API tokens found in {} — file should contain one or more `;`-separated tokens",
+        path.display()
+    );
+    let idx = pseudo_random_index(tokens.len());
+    let chosen = tokens[idx].to_string();
+    eprintln!(
+        "test_token: using workspace {}/{} (token ending …{})",
+        idx + 1,
+        tokens.len(),
+        // Last 6 chars of the chosen token — enough to identify which
+        // workspace was picked when triaging a failure, without dumping
+        // the whole secret.
+        chosen.get(chosen.len().saturating_sub(6)..).unwrap_or("?")
+    );
+    chosen
+}
+
+/// Parse a `;`- and/or newline-separated list of API tokens. Whitespace and
+/// blank entries are dropped; lines whose first non-whitespace character is
+/// `#` are treated as comments and dropped *before* `;`-splitting (so a
+/// `;` inside a comment line doesn't accidentally produce fake tokens).
+/// A trailing `;` produces an empty entry which is dropped.
+fn parse_tokens(raw: &str) -> Vec<&str> {
+    raw.lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .flat_map(|line| line.split(';'))
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+/// Cheap, dependency-free per-process pseudo-random index. Doesn't need to
+/// be cryptographically random — just needs to vary across test processes
+/// so different runs hit different tokens. Uses the process ID XORed with
+/// the current nanosecond.
+fn pseudo_random_index(len: usize) -> usize {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    let pid = std::process::id() as u64;
+    ((nanos ^ pid).wrapping_mul(6364136223846793005)) as usize % len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_token() {
+        assert_eq!(parse_tokens("lin_api_one"), vec!["lin_api_one"]);
+        assert_eq!(parse_tokens("lin_api_one\n"), vec!["lin_api_one"]);
+        assert_eq!(parse_tokens("  lin_api_one  "), vec!["lin_api_one"]);
+    }
+
+    #[test]
+    fn parse_multi_token_semicolon() {
+        assert_eq!(
+            parse_tokens("lin_api_one;lin_api_two;lin_api_three"),
+            vec!["lin_api_one", "lin_api_two", "lin_api_three"]
+        );
+    }
+
+    #[test]
+    fn trailing_semicolon_is_harmless() {
+        assert_eq!(
+            parse_tokens("lin_api_one;"),
+            vec!["lin_api_one"],
+            "single token with trailing ; should parse as one"
+        );
+        assert_eq!(
+            parse_tokens("lin_api_one;lin_api_two;"),
+            vec!["lin_api_one", "lin_api_two"]
+        );
+    }
+
+    #[test]
+    fn newlines_also_separate() {
+        assert_eq!(
+            parse_tokens("lin_api_one\nlin_api_two"),
+            vec!["lin_api_one", "lin_api_two"]
+        );
+    }
+
+    #[test]
+    fn comments_and_blanks_are_ignored() {
+        let raw = "# workspace A\nlin_api_one;\n\n# workspace B\nlin_api_two\n";
+        assert_eq!(parse_tokens(raw), vec!["lin_api_one", "lin_api_two"]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty() {
+        assert!(parse_tokens("").is_empty());
+        assert!(parse_tokens(";;;").is_empty());
+        assert!(parse_tokens("# only comments\n").is_empty());
+    }
+
+    #[test]
+    fn pseudo_random_index_in_range() {
+        for len in 1..10 {
+            let idx = pseudo_random_index(len);
+            assert!(idx < len, "idx={idx} out of range for len={len}");
+        }
+    }
 }

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -16,30 +16,78 @@ fn lineark() -> Command {
 }
 
 /// Run a lineark CLI command with retry logic.
-/// Retries up to 3 times with backoff for transient API errors (e.g., "conflict on insert").
-fn run_lineark_with_retry(args: &[&str]) -> std::process::Output {
-    for attempt in 0..3u32 {
-        if attempt > 0 {
-            std::thread::sleep(std::time::Duration::from_secs(1u64 << attempt));
-        }
-        let output = lineark()
-            .args(args)
-            .output()
-            .expect("failed to execute lineark");
-        if output.status.success() {
-            return output;
-        }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Only retry on transient "conflict on insert" errors from the Linear API.
-        if !stderr.contains("conflict on insert") {
-            return output;
-        }
-    }
-    // Final attempt without retry.
-    lineark()
+/// Run `lineark <args>` with retry on Linear's "conflict on insert" failure.
+///
+/// The conflict is a transient Linear API bug: `*Create` returns
+/// "Entity X with id <UUID> already exists" for a UUID that doesn't
+/// actually exist server-side (verified by `read` immediately returning
+/// "Entity not found"). Empirically the API has a "cold start" window —
+/// the first few project creates from a fresh test process all conflict,
+/// then it abruptly starts working. Probes locally show 3 back-to-back
+/// failures followed by 7 successes in a row.
+///
+/// The fix:
+/// 1. **Retry persistently** — up to 8 attempts with `[0, 2, 5, 10, 20,
+///    30, 45, 60]` second backoffs (~172 s worst case) so we ride out
+///    the cold window.
+/// 2. **Mutate the request body each retry** by appending a fresh suffix
+///    to the `<name>` positional. Linear's stuck UUIDs are keyed on body
+///    content, so a different body avoids the cached state on retry.
+///
+/// Returns a tuple of `(process output, name actually used on the final
+/// attempt)`. The returned name differs from the original when retries
+/// had to mutate the body — callers that look the entity up later by
+/// name **must** use this value, not their original `unique_name`, or
+/// they'll drift from server state.
+fn run_lineark_with_retry(args: &[&str]) -> (std::process::Output, String) {
+    // Locate the `<resource> create <name>` triple once so each retry can
+    // swap a fresh suffix into the same arg slot.
+    let name_idx = args.iter().position(|&a| a == "create").map(|p| p + 1);
+    let original_name = name_idx
+        .and_then(|i| args.get(i).copied())
+        .unwrap_or("")
+        .to_string();
+
+    let mut owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let mut current_name = original_name.clone();
+
+    const BACKOFFS: &[u64] = &[0, 2, 5, 10, 20, 30, 45, 60];
+
+    let mut last_output = lineark()
         .args(args)
         .output()
-        .expect("failed to execute lineark")
+        .expect("failed to execute lineark");
+
+    for &wait in BACKOFFS.iter().skip(1) {
+        if last_output.status.success() {
+            return (last_output, current_name);
+        }
+        let stderr = String::from_utf8_lossy(&last_output.stderr);
+        if !stderr.contains("conflict on insert") {
+            return (last_output, current_name);
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(wait));
+
+        // Mutate the name with a fresh suffix so the next request body
+        // differs from the previous one — Linear's stuck UUID is keyed on
+        // body content.
+        if let Some(idx) = name_idx {
+            current_name = format!(
+                "{original_name} retry-{}",
+                &uuid::Uuid::new_v4().to_string()[..6]
+            );
+            owned[idx] = current_name.clone();
+        }
+
+        let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+        last_output = lineark()
+            .args(&refs)
+            .output()
+            .expect("failed to execute lineark");
+    }
+
+    (last_output, current_name)
 }
 
 /// Helper: create a fresh test team via the SDK.
@@ -793,7 +841,7 @@ mod online {
         let team_key = team.key.clone();
 
         // Create with --priority urgent (textual).
-        let output = run_lineark_with_retry(&[
+        let (output, _) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",
@@ -2449,7 +2497,7 @@ mod online {
         let team_key = team.key.clone();
 
         // Create a project via CLI (with retry for transient "conflict on insert" errors).
-        let output = run_lineark_with_retry(&[
+        let (output, _) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",
@@ -2600,7 +2648,9 @@ mod online {
         let team_key = team.key.clone();
 
         // Create a project with --lead me (with retry for transient API errors).
-        let output = run_lineark_with_retry(&[
+        // Shadow `unique_name` so subsequent reads/asserts use the name actually
+        // sent to Linear — the helper may have appended a retry suffix.
+        let (output, unique_name) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",
@@ -2718,7 +2768,7 @@ mod online {
         let team_key = team.key.clone();
 
         // Create a project with --lead me --members me (with retry for transient API errors).
-        let output = run_lineark_with_retry(&[
+        let (output, _) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",
@@ -2815,7 +2865,7 @@ mod online {
         let team_key = team.key.clone();
 
         // Create a project with a lead and target date set.
-        let output = run_lineark_with_retry(&[
+        let (output, _) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",
@@ -4312,7 +4362,7 @@ mod online {
             "[test] CLI project filter {}",
             &uuid::Uuid::new_v4().to_string()[..8]
         );
-        let output = run_lineark_with_retry(&[
+        let (output, _) = run_lineark_with_retry(&[
             "--api-token",
             &token,
             "--format",

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -16,7 +16,7 @@ fn lineark() -> Command {
 }
 
 /// Run a lineark CLI command with retry logic.
-/// Run `lineark <args>` with retry on Linear's "conflict on insert" failure.
+/// Run `lineark <args>` with persistent retry on Linear's "conflict on insert" failure.
 ///
 /// The conflict is a transient Linear API bug: `*Create` returns
 /// "Entity X with id <UUID> already exists" for a UUID that doesn't
@@ -27,9 +27,12 @@ fn lineark() -> Command {
 /// failures followed by 7 successes in a row.
 ///
 /// The fix:
-/// 1. **Retry persistently** — up to 8 attempts with `[0, 2, 5, 10, 20,
-///    30, 45, 60]` second backoffs (~172 s worst case) so we ride out
-///    the cold window.
+/// 1. **Retry persistently inside the test** — up to 15 attempts with
+///    backoffs `[0, 2, 5, 10, 20, 30, 60, 60, 60, 60, 60, 60, 60, 60, 60]`
+///    seconds (~9 min worst case). Per-test persistence beats
+///    suite-level retry: if 1 of 67 tests can't get past Linear's
+///    cold window, retrying that one test internally is much cheaper
+///    than re-running the whole suite.
 /// 2. **Mutate the request body each retry** by appending a fresh suffix
 ///    to the `<name>` positional. Linear's stuck UUIDs are keyed on body
 ///    content, so a different body avoids the cached state on retry.
@@ -40,18 +43,27 @@ fn lineark() -> Command {
 /// name **must** use this value, not their original `unique_name`, or
 /// they'll drift from server state.
 fn run_lineark_with_retry(args: &[&str]) -> (std::process::Output, String) {
-    // Locate the `<resource> create <name>` triple once so each retry can
-    // swap a fresh suffix into the same arg slot.
+    // Decide whether we can safely mutate the request body between retries.
+    //
+    // Most `<resource> create <name>` subcommands take a text name positional
+    // (labels/issues/teams/projects/milestones), where mutating the name
+    // with a fresh suffix is exactly the trick that dodges Linear's phantom
+    // UUID conflicts. But `comments create <issue-uuid>` and
+    // `relations create <issue-uuid>` take a UUID positional — mutating
+    // that would corrupt the request and the mutation would definitely
+    // fail. Gate mutation on the `[test]` prefix our test naming
+    // convention uses, so we only rewrite text we know is ours.
     let name_idx = args.iter().position(|&a| a == "create").map(|p| p + 1);
-    let original_name = name_idx
+    let original_positional = name_idx
         .and_then(|i| args.get(i).copied())
         .unwrap_or("")
         .to_string();
+    let mutable_name = original_positional.starts_with("[test]");
 
     let mut owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-    let mut current_name = original_name.clone();
+    let mut current_name = original_positional.clone();
 
-    const BACKOFFS: &[u64] = &[0, 2, 5, 10, 20, 30, 45, 60];
+    const BACKOFFS: &[u64] = &[0, 2, 5, 10, 20, 30, 60, 60, 60, 60, 60, 60, 60, 60, 60];
 
     let mut last_output = lineark()
         .args(args)
@@ -71,13 +83,15 @@ fn run_lineark_with_retry(args: &[&str]) -> (std::process::Output, String) {
 
         // Mutate the name with a fresh suffix so the next request body
         // differs from the previous one — Linear's stuck UUID is keyed on
-        // body content.
-        if let Some(idx) = name_idx {
-            current_name = format!(
-                "{original_name} retry-{}",
-                &uuid::Uuid::new_v4().to_string()[..6]
-            );
-            owned[idx] = current_name.clone();
+        // body content. Only safe for text names we own (`[test] ...`).
+        if mutable_name {
+            if let Some(idx) = name_idx {
+                current_name = format!(
+                    "{original_positional} retry-{}",
+                    &uuid::Uuid::new_v4().to_string()[..6]
+                );
+                owned[idx] = current_name.clone();
+            }
         }
 
         let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
@@ -216,20 +230,17 @@ mod online {
 
         // Create a workspace-level label.
         let unique_name = format!("[test] lbl-crud {}", &uuid::Uuid::new_v4().to_string()[..8]);
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "labels",
-                "create",
-                &unique_name,
-                "--color",
-                "#eb5757",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, unique_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "labels",
+            "create",
+            &unique_name,
+            "--color",
+            "#eb5757",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -300,21 +311,18 @@ mod online {
 
         // 1. Create a group label with --group.
         let group_name = format!("[test] Group {uid}");
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "labels",
-                "create",
-                &group_name,
-                "--color",
-                "#000000",
-                "--make-label-group",
-            ])
-            .output()
-            .unwrap();
+        let (output, group_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "labels",
+            "create",
+            &group_name,
+            "--color",
+            "#000000",
+            "--make-label-group",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -330,22 +338,19 @@ mod online {
 
         // 2. Create a child label under the group.
         let child_name = format!("[test] Child {uid}");
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "labels",
-                "create",
-                &child_name,
-                "--color",
-                "#ffffff",
-                "--parent-label-group",
-                &group_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, child_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "labels",
+            "create",
+            &child_name,
+            "--color",
+            "#ffffff",
+            "--parent-label-group",
+            &group_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -477,20 +482,17 @@ mod online {
         // Create a label with a space in the name.
         let uid = &uuid::Uuid::new_v4().to_string()[..8];
         let label_name = format!("[test] Tech Debt {uid}");
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "labels",
-                "create",
-                &label_name,
-                "--color",
-                "#eb5757",
-            ])
-            .output()
-            .unwrap();
+        let (output, label_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "labels",
+            "create",
+            &label_name,
+            "--color",
+            "#eb5757",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -506,22 +508,19 @@ mod online {
 
         // Create an issue with the spaced label.
         let issue_title = format!("[test] spaced label {uid}");
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &issue_title,
-                "--team",
-                &team_id,
-                "--labels",
-                &label_name,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &issue_title,
+            "--team",
+            &team_id,
+            "--labels",
+            &label_name,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -758,24 +757,21 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-                "--description",
-                "Automated CLI test — will be archived.",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, unique_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+            "--description",
+            "Automated CLI test — will be archived.",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -988,23 +984,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success(), "issue creation should succeed");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"]
             .as_str()
@@ -1139,23 +1137,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success(), "issue creation should succeed");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"].as_str().unwrap().to_string();
         let _issue_guard = IssueGuard {
@@ -1237,23 +1237,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue to delete.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success(), "issue creation should succeed");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"]
             .as_str()
@@ -1304,23 +1306,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"]
             .as_str()
@@ -1393,22 +1397,19 @@ mod online {
         let team = create_test_team();
         let team_key = team.key.clone();
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &issue_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &issue_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
         assert!(output.status.success(), "issue creation should succeed");
         let issue: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = issue["id"].as_str().unwrap().to_string();
@@ -1418,23 +1419,20 @@ mod online {
         };
 
         // Create a document associated with the issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "documents",
-                "create",
-                "--title",
-                &doc_name,
-                "--content",
-                "Automated CLI test document.",
-                "--issue",
-                &issue_id,
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "documents",
+            "create",
+            "--title",
+            &doc_name,
+            "--content",
+            "Automated CLI test document.",
+            "--issue",
+            &issue_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -1852,23 +1850,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create two issues.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] relation parent {suffix}"),
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] relation parent {suffix}"),
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let issue_a: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_a_id = issue_a["id"].as_str().unwrap().to_string();
         let _issue_a_guard = IssueGuard {
@@ -1876,23 +1876,25 @@ mod online {
             id: issue_a_id.clone(),
         };
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] relation child {suffix}"),
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] relation child {suffix}"),
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let issue_b: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_b_id = issue_b["id"].as_str().unwrap().to_string();
         let _issue_b_guard = IssueGuard {
@@ -1979,22 +1981,19 @@ mod online {
         let team_key = team.key.clone();
 
         // Create a parent issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] parent with children {suffix}"),
-                "--team",
-                &team_key,
-                "-p",
-                "4",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] parent with children {suffix}"),
+            "--team",
+            &team_key,
+            "-p",
+            "4",
+        ]);
         assert!(
             output.status.success(),
             "parent issue creation should succeed"
@@ -2007,24 +2006,21 @@ mod online {
         };
 
         // Create a child issue with --parent.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] child issue {suffix}"),
-                "--team",
-                &team_key,
-                "-p",
-                "4",
-                "--parent",
-                &parent_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] child issue {suffix}"),
+            "--team",
+            &team_key,
+            "-p",
+            "4",
+            "--parent",
+            &parent_id,
+        ]);
         assert!(
             output.status.success(),
             "child issue creation should succeed"
@@ -2037,20 +2033,17 @@ mod online {
         };
 
         // Add a comment on the parent.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "comments",
-                "create",
-                &parent_id,
-                "--body",
-                "Test comment for children+comments test",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "comments",
+            "create",
+            &parent_id,
+            "--body",
+            "Test comment for children+comments test",
+        ]);
         assert!(output.status.success(), "comment creation should succeed");
 
         // Read the parent — should include children and comments.
@@ -2199,23 +2192,25 @@ mod online {
         let team_key = team.key.clone();
 
         // Create parent.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] clear-parent parent {suffix}"),
-                "--team",
-                &team_key,
-                "-p",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] clear-parent parent {suffix}"),
+            "--team",
+            &team_key,
+            "-p",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let parent: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let parent_id = parent["id"].as_str().unwrap().to_string();
         let _parent_guard = IssueGuard {
@@ -2224,25 +2219,27 @@ mod online {
         };
 
         // Create child with --parent.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] clear-parent child {suffix}"),
-                "--team",
-                &team_key,
-                "-p",
-                "4",
-                "--parent",
-                &parent_id,
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] clear-parent child {suffix}"),
+            "--team",
+            &team_key,
+            "-p",
+            "4",
+            "--parent",
+            &parent_id,
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let child: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let child_id = child["id"].as_str().unwrap().to_string();
         let _child_guard = IssueGuard {
@@ -2333,24 +2330,21 @@ mod online {
         };
 
         // Create a milestone via CLI (use project_id to avoid ambiguity with stale data).
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "project-milestones",
-                "create",
-                &milestone_name,
-                "--project",
-                &project_id,
-                "--target-date",
-                "2026-12-31",
-                "--description",
-                "Test milestone for CLI CRUD.",
-            ])
-            .output()
-            .unwrap();
+        let (output, milestone_name) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "project-milestones",
+            "create",
+            &milestone_name,
+            "--project",
+            &project_id,
+            "--target-date",
+            "2026-12-31",
+            "--description",
+            "Test milestone for CLI CRUD.",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3053,24 +3047,21 @@ mod online {
         let my_name = whoami["name"].as_str().unwrap_or("").to_string();
 
         // Create an issue with --assignee me.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--assignee",
-                "me",
-                "--priority",
-                "4",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--assignee",
+            "me",
+            "--priority",
+            "4",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3130,23 +3121,25 @@ mod online {
         let my_name = whoami["name"].as_str().unwrap_or("").to_string();
 
         // Create an unassigned issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(output.status.success());
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"].as_str().unwrap().to_string();
         let _issue_guard = IssueGuard {
@@ -3224,22 +3217,19 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue to comment on.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
         assert!(output.status.success(), "issue creation should succeed");
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"]
@@ -3251,20 +3241,17 @@ mod online {
         };
 
         // Create a comment (use UUID to avoid search index lag).
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "comments",
-                "create",
-                issue_id,
-                "--body",
-                "Automated CLI test comment.",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "comments",
+            "create",
+            issue_id,
+            "--body",
+            "Automated CLI test comment.",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3293,22 +3280,19 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue to comment on.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
         assert!(output.status.success(), "issue creation should succeed");
         let created: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         let issue_id = created["id"]
@@ -3321,20 +3305,17 @@ mod online {
         };
 
         // Create a comment.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "comments",
-                "create",
-                &issue_id,
-                "--body",
-                "Comment that will be deleted.",
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "comments",
+            "create",
+            &issue_id,
+            "--body",
+            "Comment that will be deleted.",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3426,18 +3407,15 @@ mod online {
             "[test] tm-create {}",
             &uuid::Uuid::new_v4().to_string()[..8]
         );
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "teams",
-                "create",
-                &unique_name,
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "teams",
+            "create",
+            &unique_name,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3489,20 +3467,17 @@ mod online {
 
         // Create a team.
         let unique_name = format!("[test] tm-crud {}", &uuid::Uuid::new_v4().to_string()[..8]);
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "teams",
-                "create",
-                &unique_name,
-                "--description",
-                "Original description.",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "teams",
+            "create",
+            &unique_name,
+            "--description",
+            "Original description.",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3595,18 +3570,15 @@ mod online {
             "[test] tm-members {}",
             &uuid::Uuid::new_v4().to_string()[..8]
         );
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "teams",
-                "create",
-                &unique_name,
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "teams",
+            "create",
+            &unique_name,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3736,23 +3708,26 @@ mod online {
         team_key: &str,
     ) -> ((String, IssueGuard), (String, IssueGuard)) {
         let suffix = &uuid::Uuid::new_v4().to_string()[..8];
-        let out1 = lineark()
-            .args([
-                "--api-token",
-                token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] relation issue A {suffix}"),
-                "--team",
-                team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(out1.status.success(), "issue A creation should succeed");
+        let name_a = format!("[test] relation issue A {suffix}");
+        let (out1, _) = run_lineark_with_retry(&[
+            "--api-token",
+            token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &name_a,
+            "--team",
+            team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&out1.stdout);
+        let stderr = String::from_utf8_lossy(&out1.stderr);
+        assert!(
+            out1.status.success(),
+            "issue A creation should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let a: serde_json::Value = serde_json::from_slice(&out1.stdout).unwrap();
         let a_id = a["id"].as_str().unwrap().to_string();
         let a_guard = IssueGuard {
@@ -3760,23 +3735,26 @@ mod online {
             id: a_id.clone(),
         };
 
-        let out2 = lineark()
-            .args([
-                "--api-token",
-                token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!("[test] relation issue B {suffix}"),
-                "--team",
-                team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .unwrap();
-        assert!(out2.status.success(), "issue B creation should succeed");
+        let name_b = format!("[test] relation issue B {suffix}");
+        let (out2, _) = run_lineark_with_retry(&[
+            "--api-token",
+            token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &name_b,
+            "--team",
+            team_key,
+            "--priority",
+            "4",
+        ]);
+        let stdout = String::from_utf8_lossy(&out2.stdout);
+        let stderr = String::from_utf8_lossy(&out2.stderr);
+        assert!(
+            out2.status.success(),
+            "issue B creation should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
         let b: serde_json::Value = serde_json::from_slice(&out2.stdout).unwrap();
         let b_id = b["id"].as_str().unwrap().to_string();
         let b_guard = IssueGuard {
@@ -3794,20 +3772,17 @@ mod online {
         let team_key = team.key.clone();
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--blocks",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--blocks",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3827,20 +3802,17 @@ mod online {
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
         // "A --blocked-by B" means B blocks A.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--blocked-by",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--blocked-by",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3859,20 +3831,17 @@ mod online {
         let team_key = team.key.clone();
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--related",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--related",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3891,20 +3860,17 @@ mod online {
         let team_key = team.key.clone();
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--duplicate",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--duplicate",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3923,20 +3889,17 @@ mod online {
         let team_key = team.key.clone();
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--similar",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--similar",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -3956,20 +3919,17 @@ mod online {
         let ((a_id, _ga), (b_id, _gb)) = create_two_issues(&token, &team_key);
 
         // Create a relation.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "relations",
-                "create",
-                &a_id,
-                "--blocks",
-                &b_id,
-            ])
-            .output()
-            .unwrap();
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "relations",
+            "create",
+            &a_id,
+            "--blocks",
+            &b_id,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -4038,20 +3998,17 @@ mod online {
 
         // Create a comment (retry to allow issue propagation).
         let comment_id = retry_with_backoff(8, || {
-            let output = lineark()
-                .args([
-                    "--api-token",
-                    &token,
-                    "--format",
-                    "json",
-                    "comments",
-                    "create",
-                    &issue_id,
-                    "--body",
-                    "Original body",
-                ])
-                .output()
-                .unwrap();
+            let (output, _) = run_lineark_with_retry(&[
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "comments",
+                "create",
+                &issue_id,
+                "--body",
+                "Original body",
+            ]);
             if !output.status.success() {
                 return Err(String::from_utf8_lossy(&output.stderr).to_string());
             }
@@ -4196,20 +4153,17 @@ mod online {
 
         // Create a parent comment via CLI (retry to allow issue propagation).
         let parent_id = retry_with_backoff(8, || {
-            let output = lineark()
-                .args([
-                    "--api-token",
-                    &token,
-                    "--format",
-                    "json",
-                    "comments",
-                    "create",
-                    &issue_id,
-                    "--body",
-                    "Parent comment thread",
-                ])
-                .output()
-                .unwrap();
+            let (output, _) = run_lineark_with_retry(&[
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "comments",
+                "create",
+                &issue_id,
+                "--body",
+                "Parent comment thread",
+            ]);
             if !output.status.success() {
                 return Err(String::from_utf8_lossy(&output.stderr).to_string());
             }
@@ -4394,25 +4348,22 @@ mod online {
         };
 
         // Create an issue inside that project.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &format!(
-                    "[test] project filter issue {}",
-                    &uuid::Uuid::new_v4().to_string()[..8]
-                ),
-                "--team",
-                &team_key,
-                "--project",
-                &project_name,
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!(
+                "[test] project filter issue {}",
+                &uuid::Uuid::new_v4().to_string()[..8]
+            ),
+            "--team",
+            &team_key,
+            "--project",
+            &project_name,
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -4486,24 +4437,21 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue with --estimate.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-                "--estimate",
-                "3",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+            "--estimate",
+            "3",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -4614,22 +4562,19 @@ mod online {
         let team_key = team.key.clone();
 
         // Create an issue.
-        let output = lineark()
-            .args([
-                "--api-token",
-                &token,
-                "--format",
-                "json",
-                "issues",
-                "create",
-                &unique_name,
-                "--team",
-                &team_key,
-                "--priority",
-                "4",
-            ])
-            .output()
-            .expect("failed to execute lineark");
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &unique_name,
+            "--team",
+            &team_key,
+            "--priority",
+            "4",
+        ]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(


### PR DESCRIPTION
## Problem

CI's **Tests (Online)** job had been flaking on `*Create` mutations for several PRs running. Linear's GraphQL API has structural consistency issues that aren't transient (despite looking like flakes): `*Create` mutations sometimes return `"Entity X with id <UUID> already exists"` for a UUID that doesn't actually exist server-side, soft-deleted resources accumulate as zombies counting against free-plan limits, and freshly-created resources may not be queryable for several seconds.

Same pattern hit PR #140's post-merge CI before the work in #141 even started — confirming the issue is structural, not introduced by recent work.

## Approach

Treat Linear's quirks as the environment we're testing against, not bugs to wait out. Codify three mandatory pillars for every online test (added to `CLAUDE.md`) and retrofit the entire suite to follow them.

### The three pillars

**1. Proactive cleanup.** Never assume the workspace is empty; never leak resources between tests.

- `cleanup_workspace` in `lineark-test-utils` had a real bug: it queried `client.X().first(250).send()` *without* `include_archived(true)`, so soft-deleted projects/issues/documents from prior runs were silently invisible. We discovered 24 zombie teams + 10 stuck-in-trash projects accumulated this way. Fixed.
- Every test uses `create_test_team()` (calls `cleanup_zombies()` once per process + assigns a unique team key) and wraps every created resource in the matching RAII `*Guard` immediately after the create returns. Guards delete on drop so cleanup happens even when later asserts panic.
- The `cleanup-test-workspace` binary now iterates **every** pooled workspace (not just the random one it draws), so any workspace silently accumulating zombies because it kept losing the random draw still gets tidied.

**2. Unique names per attempt.** Linear's API returns phantom "conflict on insert" errors keyed on request body content, so retries with identical bodies hit the same sticky conflict.

- Generate a per-test random suffix: `format!("[test] <what> {}", &uuid::Uuid::new_v4().to_string()[..8])`.
- 6 SDK tests had hardcoded titles like `"[test] SDK issue_create_and_delete"` — no UUID suffix. Two test runs would collide. Added suffixes.
- `run_lineark_with_retry` mutates the `<name>` positional between attempts (appends `retry-<uuid6>`) so each retry sends a different body. Mutation is gated on `[test]` prefix so `comments create <uuid>` and `relations create <uuid>` (which take UUID positionals) aren't corrupted.
- Returns `(Output, String)` so callers can shadow their `unique_name` with the actually-used name for downstream `read-by-name` lookups.

**3. Retries on every transient-capable call.**

- 32 CLI tests + the `create_two_issues` helper called `lineark <resource> create` directly via `lineark().args(...).output()`, bypassing `run_lineark_with_retry`. Converted all 30+ sites.
- `run_lineark_with_retry` bumped to **15 attempts** with `[0, 2, 5, 10, 20, 30, 60×9]`s backoffs (~9 min worst case) — persistent enough to ride out Linear's cold window without needing a suite-level wrapper.
- `retry_create` in `lineark-test-utils` (used by SDK tests) bumped from 3 → 15 attempts to match.
- **Suite-level retry removed.** The previous version wrapped the whole online suite in a 3x retry — wasteful (re-ran 60+ passing tests because 1 failed) and counter-productive (suite-level retries are no longer needed when per-call retries are persistent). Replaced with single-shot suite invocation.
- `continue-on-error: true` from an earlier emergency patch is also gone.

### Multi-workspace token rotation

`~/.linear_api_token_test` and the `LINEAR_TEST_TOKEN` GitHub secret now accept a `;`-separated pool of API tokens — one per workspace. `test_token()` picks one at random per test process and pins it for the process lifetime via `OnceLock`. Across runs the load distributes ~uniformly across N workspaces, spreading pressure on Linear's free-plan resource limits and trash-retention quirks.

Format details (with unit tests):
- `;` is the primary separator; newlines also work.
- Trailing `;` is harmless; `#`-prefixed comment lines are dropped.
- Comment filtering happens *before* `;`-splitting, so a `;` inside a comment doesn't accidentally produce fake "tokens".
- Single-line single-token files (the original format) work unchanged.
- `test_token()` logs `using workspace N/total (token …<last6>)` at process start so a CI-failure triage can instantly identify which workspace was hit.

This PR ships configured with **3 fresh workspaces** (cadu-test-2/3/4). The previous workspace (cadus-test-workspace) had 10 trashed projects stuck on Linear's 30-day retention cycle — Linear's API has no permanent-delete for projects, so we abandoned it for fresh workspaces with no stuck history.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `make test` — 235 offline tests pass (this is test-only code; offline suite is unaffected by design)
- [x] `make test-online` — 107 online tests pass locally (67 CLI + 40 SDK)
- [x] CI **all 8 checks green**: Lint, Tests (Offline), Tests (Online), 5 Build targets
- [x] CI logs show all 3 pooled workspaces being visited per run (cleanup hits all 3, test processes pick at random)
- [x] No `serde_json::Value::Null` injection or hand-written `mutation(...)` strings remain under `crates/lineark/src/commands/`