### PR TITLE
docs(projects): warn that Linear's API rejects emoji for --icon

### DIFF
--- a/crates/lineark/src/commands/projects.rs
+++ b/crates/lineark/src/commands/projects.rs
@@ -75,7 +75,7 @@ pub enum ProjectsAction {
         /// Markdown content for the project.
         #[arg(long)]
         content: Option<String>,
-        /// Project icon (emoji or icon name).
+        /// Project icon name (e.g., "Computer", "Database", "Cloud"). Linear's API rejects emoji despite the GraphQL schema docstring claiming otherwise.
         #[arg(long)]
         icon: Option<String>,
         /// Project color (hex color code).
@@ -131,7 +131,7 @@ pub enum ProjectsAction {
         /// Project status name or UUID.
         #[arg(long)]
         status: Option<String>,
-        /// Project icon (emoji or icon name).
+        /// Project icon name (e.g., "Computer", "Database", "Cloud"). Linear's API rejects emoji despite the GraphQL schema docstring claiming otherwise.
         #[arg(long)]
         icon: Option<String>,
         /// Project color (hex color code).

--- a/crates/lineark/src/commands/projects.rs
+++ b/crates/lineark/src/commands/projects.rs
@@ -75,7 +75,7 @@ pub enum ProjectsAction {
         /// Markdown content for the project.
         #[arg(long)]
         content: Option<String>,
-        /// Project icon name (e.g., "Computer", "Database", "Cloud"). Linear's API rejects emoji despite the GraphQL schema docstring claiming otherwise.
+        /// Project icon: an emoji shortcode like ":repeat:" (NOT raw unicode 🔁) or a Linear named icon like "Computer". Linear's API rejects raw unicode emoji.
         #[arg(long)]
         icon: Option<String>,
         /// Project color (hex color code).
@@ -131,7 +131,7 @@ pub enum ProjectsAction {
         /// Project status name or UUID.
         #[arg(long)]
         status: Option<String>,
-        /// Project icon name (e.g., "Computer", "Database", "Cloud"). Linear's API rejects emoji despite the GraphQL schema docstring claiming otherwise.
+        /// Project icon: an emoji shortcode like ":repeat:" (NOT raw unicode 🔁) or a Linear named icon like "Computer". Linear's API rejects raw unicode emoji.
         #[arg(long)]
         icon: Option<String>,
         /// Project color (hex color code).

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -522,19 +522,22 @@ fn projects_create_help_shows_flags() {
         .stdout(predicate::str::contains("--color"));
 }
 
-/// Regression test for #146: `--icon` help text must warn that emoji are
-/// rejected by Linear's API, despite the GraphQL schema docstring claiming
-/// otherwise. Without this warning, users (especially LLM consumers) follow
-/// the schema-documented "emoji or icon name" wording and hit a confusing
-/// `INVALID_INPUT` error from the upstream validator.
+/// Regression test for #146: `--icon` help text must document the two
+/// formats Linear's API actually accepts — emoji *shortcodes* (`:repeat:`)
+/// and named icons (`Computer`) — and warn that raw unicode emoji (`🔁`)
+/// are rejected at runtime despite the GraphQL schema docstring claiming
+/// otherwise. Without this, users (especially LLM consumers) reach for
+/// raw unicode and hit a confusing `INVALID_INPUT` error from the
+/// upstream validator.
 #[test]
-fn projects_create_help_icon_warns_emoji_rejected() {
+fn projects_create_help_icon_documents_accepted_formats() {
     lineark()
         .args(["projects", "create", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Linear's API rejects emoji"))
-        .stdout(predicate::str::contains("Computer"));
+        .stdout(predicate::str::contains(":repeat:"))
+        .stdout(predicate::str::contains("Computer"))
+        .stdout(predicate::str::contains("rejects raw unicode emoji"));
 }
 
 #[test]
@@ -561,15 +564,16 @@ fn projects_update_help_shows_flags() {
         .stdout(predicate::str::contains("--labels"));
 }
 
-/// Regression test for #146 — same warning must appear on `update` help.
+/// Regression test for #146 — same documentation must appear on `update` help.
 #[test]
-fn projects_update_help_icon_warns_emoji_rejected() {
+fn projects_update_help_icon_documents_accepted_formats() {
     lineark()
         .args(["projects", "update", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Linear's API rejects emoji"))
-        .stdout(predicate::str::contains("Computer"));
+        .stdout(predicate::str::contains(":repeat:"))
+        .stdout(predicate::str::contains("Computer"))
+        .stdout(predicate::str::contains("rejects raw unicode emoji"));
 }
 
 #[test]

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -522,6 +522,56 @@ fn projects_create_help_shows_flags() {
         .stdout(predicate::str::contains("--color"));
 }
 
+/// Regression test for #146: `--icon` help text must warn that emoji are
+/// rejected by Linear's API, despite the GraphQL schema docstring claiming
+/// otherwise. Without this warning, users (especially LLM consumers) follow
+/// the schema-documented "emoji or icon name" wording and hit a confusing
+/// `INVALID_INPUT` error from the upstream validator.
+#[test]
+fn projects_create_help_icon_warns_emoji_rejected() {
+    lineark()
+        .args(["projects", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Linear's API rejects emoji"))
+        .stdout(predicate::str::contains("Computer"));
+}
+
+#[test]
+fn projects_update_help_shows_flags() {
+    lineark()
+        .args(["projects", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--description"))
+        .stdout(predicate::str::contains("--content"))
+        .stdout(predicate::str::contains("--lead"))
+        .stdout(predicate::str::contains("--clear-lead"))
+        .stdout(predicate::str::contains("--members"))
+        .stdout(predicate::str::contains("--team"))
+        .stdout(predicate::str::contains("--start-date"))
+        .stdout(predicate::str::contains("--clear-start-date"))
+        .stdout(predicate::str::contains("--target-date"))
+        .stdout(predicate::str::contains("--clear-target-date"))
+        .stdout(predicate::str::contains("--priority"))
+        .stdout(predicate::str::contains("--status"))
+        .stdout(predicate::str::contains("--icon"))
+        .stdout(predicate::str::contains("--color"))
+        .stdout(predicate::str::contains("--labels"));
+}
+
+/// Regression test for #146 — same warning must appear on `update` help.
+#[test]
+fn projects_update_help_icon_warns_emoji_rejected() {
+    lineark()
+        .args(["projects", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Linear's API rejects emoji"))
+        .stdout(predicate::str::contains("Computer"));
+}
+
 #[test]
 fn projects_list_help_shows_led_by_me_flag() {
     lineark()


### PR DESCRIPTION
## Summary

Linear's API actually accepts emoji as `--icon` — but **only as colon-wrapped shortcodes** (`:repeat:`, `:computer:`), not as raw unicode characters (`🔁`). The schema docstring "Can be an emoji or a decorative icon type" is technically truthful; the gap is purely UX — users (and SDKs, and LLMs) reasonably read "emoji" as "the unicode character" and hit a confusing `INVALID_INPUT` error.

This PR updates the `--icon` help text on `projects create` and `projects update` to document both accepted formats and explicitly warn that raw unicode is rejected:

```
--icon <ICON>
    Project icon: an emoji shortcode like ":repeat:" (NOT raw unicode 🔁) or a Linear
    named icon like "Computer". Linear's API rejects raw unicode emoji.
```

`lineark-sdk` and the request layer are unchanged — the rejection of raw unicode comes purely from Linear's upstream validator (proven by the raw `urllib` reproduction in #146).

## Verified accepted/rejected formats

| Input | Result |
| --- | --- |
| `🔁` (raw unicode) | ❌ rejected |
| `:repeat:` (shortcode) | ✅ accepted |
| `:computer:` | ✅ accepted |
| `Computer` (PascalCase named icon) | ✅ accepted |
| `computer` (lowercase) | ❌ rejected |
| `sweat_smile` (no colons) | ❌ rejected |
| `sweat-smile` (hyphens) | ❌ rejected |

## Test plan

- [x] `make check` passes
- [x] `make test` passes
- [x] New regression tests `projects_create_help_icon_documents_accepted_formats` and `projects_update_help_icon_documents_accepted_formats` assert both `:repeat:` and `Computer` examples plus the "rejects raw unicode emoji" warning appear in `--help` output
- [x] New `projects_update_help_shows_flags` covers the previously-untested update help surface
- [x] Manually verified the rendered `--help` output

## Out of scope (good follow-ups)

- Auto-translate raw unicode → shortcode in lineark (`🔁` → `:repeat:`) so the schema docstring's promise becomes literally true at the CLI layer.
- `lineark icons list` subcommand bundling Linear's named-icon catalog.
- Apply the same wording fix to other `icon` fields (teams, custom views, dashboards, documents, project templates) once their accepted formats are verified.

Closes #146