### PR TITLE
fix(issues): include project, cycle, parent, milestone in issues read

### DIFF
--- a/crates/lineark/src/commands/issues.rs
+++ b/crates/lineark/src/commands/issues.rs
@@ -43,7 +43,7 @@ pub enum IssuesAction {
         #[arg(long, default_value = "false")]
         show_done: bool,
     },
-    /// Show full details for a single issue, including assignee, state, labels, description, sub-issues, and comments.
+    /// Show full details for a single issue, including assignee, state, project, cycle, parent, labels, description, sub-issues, and comments.
     Read {
         /// Issue identifier (e.g., E-929) or UUID.
         identifier: String,
@@ -413,6 +413,14 @@ pub struct IssueDetail {
     #[graphql(nested)]
     pub team: Option<TeamRef>,
     #[graphql(nested)]
+    pub project: Option<ProjectRef>,
+    #[graphql(nested)]
+    pub project_milestone: Option<MilestoneRef>,
+    #[graphql(nested)]
+    pub cycle: Option<CycleRef>,
+    #[graphql(nested)]
+    pub parent: Option<RelatedIssueRef>,
+    #[graphql(nested)]
     pub labels: Option<LabelConnection>,
     #[graphql(nested)]
     pub relations: Option<RelationConnection>,
@@ -448,6 +456,31 @@ pub struct TeamRef {
     pub id: Option<String>,
     pub name: Option<String>,
     pub key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, GraphQLFields)]
+#[graphql(full_type = lineark_sdk::generated::types::Project)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ProjectRef {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, GraphQLFields)]
+#[graphql(full_type = lineark_sdk::generated::types::ProjectMilestone)]
+#[serde(rename_all = "camelCase", default)]
+pub struct MilestoneRef {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, GraphQLFields)]
+#[graphql(full_type = lineark_sdk::generated::types::Cycle)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CycleRef {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub number: Option<f64>,
 }
 
 /// Wrapper around IssueLabelConnection that serializes as a flat list of names:

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -82,7 +82,7 @@ COMMANDS:
   lineark issues list [-l N] [--team KEY]          Active issues (done/canceled hidden), newest first
     [--project NAME-OR-ID] [--mine]                Filter by project, assignee
     [--show-done]                                  Include done/canceled issues
-  lineark issues read <IDENTIFIER>                 Full issue detail incl. sub-issues, comments, relations
+  lineark issues read <IDENTIFIER>                 Full issue detail incl. project, sub-issues, comments, relations
   lineark issues find-branch <BRANCH>              Find issue by Git branch name
   lineark issues search <QUERY> [-l N]             Full-text search
     [--team KEY] [--assignee NAME-OR-ID|me]        Filter by team, assignee, status

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -4616,6 +4616,14 @@ mod online {
             detail.get("estimate").is_some(),
             "issues read output should have an 'estimate' field"
         );
+        // Regression for #149: these association fields must be present in the
+        // output (as null here, since this issue has none), not silently omitted.
+        for key in ["project", "projectMilestone", "cycle", "parent"] {
+            assert!(
+                detail.get(key).is_some(),
+                "issues read output should have a '{key}' key.\nstdout: {stdout}"
+            );
+        }
     }
 
     // ── Batch update ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #149. `lineark issues read <ID>` never returned the issue's **project** (nor `cycle`, `parent`, or `projectMilestone`) — the keys were entirely absent from the output, not null.

`IssueDetail` (the zero-overfetch type whose shape *is* the GraphQL query shape) selected `state`/`assignee`/`team` but had no `project`/`cycle`/`parent`/`projectMilestone` fields, so the generated query never requested them.

## Changes

- Add `ProjectRef`, `MilestoneRef`, and `CycleRef` nested ref types (mirroring the existing `TeamRef`/`StateRef` pattern).
- Wire `project`, `project_milestone`, `cycle`, and `parent` (reusing `RelatedIssueRef`) onto `IssueDetail`. The `GraphQLFields` derive wires both the query and the serialized output automatically.
- Update the `issues read` help text and `usage` reference to mention project.

Both `--format json` and `--format human` now surface these associations (human renderer skips null fields; JSON includes them as null when absent).

## Test plan

- `make check` ✅
- `make test` (offline) ✅ — 47 passed
- Online: extended `issues_read_json_includes_estimate_field` to assert the `project`, `projectMilestone`, `cycle`, and `parent` keys are present. Ran against the live API ✅ — 1 passed.