### PR TITLE
feat(issues): add --clear-project, --clear-cycle, --clear-assignee; surface project retirement in usage

### DIFF
--- a/crates/lineark/README.md
+++ b/crates/lineark/README.md
@@ -73,6 +73,10 @@ lineark projects create <NAME> --team KEY        Create a project
   [--members NAME,...|me]                        Project members (comma-separated)
   [--start-date DATE] [--target-date DATE]       Priority, content, icon, color
   [-p PRIORITY] [--content TEXT] ...             See --help for all options
+lineark projects update <NAME-OR-ID>             Update a project
+  [--status NAME]                                No archive command — retire via
+                                                 --status "Completed"/"Canceled"
+  [--name TEXT] [--lead NAME-OR-ID|me] ...       See --help for all options
 lineark labels list [--team KEY]                 List labels (group, team, parent)
 lineark labels create <NAME>                     Create a label
   [--team KEY] [--color HEX]                     Team, color
@@ -100,10 +104,14 @@ lineark issues create <TITLE> --team KEY         Create an issue
   [--labels NAME,...] [-s NAME] ...              Labels, status — see --help
 lineark issues update <IDENTIFIER>               Update an issue
   [-s NAME] [-p PRIORITY] [-e N]                 Status, priority, estimate
-  [--assignee NAME-OR-ID|me]                     Assignee
-  [--clear-parent] [--project NAME-OR-ID] ...    See --help for all options
+  [--assignee NAME-OR-ID|me] [--clear-assignee]  Assign or unassign
+  [--project NAME-OR-ID] [--clear-project]       Set or remove project
+  [--cycle NAME-OR-ID] [--clear-cycle]           Set or remove cycle
+  [--parent ID] [--clear-parent] ...             See --help for all options
 lineark issues batch-update ID [ID ...]          Batch update multiple issues
   [-s NAME] [-p PRIORITY] [--assignee ...]       Status, priority, assignee
+  [--clear-project] [--clear-cycle]              Clear relations in bulk
+  [--clear-assignee]
 lineark issues archive <IDENTIFIER>              Archive an issue
 lineark issues unarchive <IDENTIFIER>            Unarchive an issue
 lineark issues delete <IDENTIFIER>               Delete (trash) an issue

--- a/crates/lineark/src/commands/issues.rs
+++ b/crates/lineark/src/commands/issues.rs
@@ -170,12 +170,21 @@ pub enum IssuesAction {
         /// Assignee: user name, display name, UUID, or `me`.
         #[arg(long)]
         assignee: Option<String>,
+        /// Remove the assignee (unassign the issues).
+        #[arg(long, default_value = "false", conflicts_with = "assignee")]
+        clear_assignee: bool,
         /// Project name or UUID.
         #[arg(long)]
         project: Option<String>,
+        /// Remove the issues from their project.
+        #[arg(long, default_value = "false", conflicts_with = "project")]
+        clear_project: bool,
         /// Cycle name, number, or UUID (resolved within the first issue's team).
         #[arg(long)]
         cycle: Option<String>,
+        /// Remove the issues from their cycle.
+        #[arg(long, default_value = "false", conflicts_with = "cycle")]
+        clear_cycle: bool,
     },
     /// Update an existing issue. Returns the updated issue.
     ///
@@ -207,6 +216,9 @@ pub enum IssuesAction {
         /// Assignee: user name, display name, UUID, or `me`.
         #[arg(long)]
         assignee: Option<String>,
+        /// Remove the assignee (unassign the issue).
+        #[arg(long, default_value = "false", conflicts_with = "assignee")]
+        clear_assignee: bool,
         /// Parent issue identifier (e.g., ENG-123) or UUID.
         #[arg(long)]
         parent: Option<String>,
@@ -222,9 +234,15 @@ pub enum IssuesAction {
         /// Project name or UUID.
         #[arg(long)]
         project: Option<String>,
+        /// Remove the issue from its project.
+        #[arg(long, default_value = "false", conflicts_with = "project")]
+        clear_project: bool,
         /// Cycle name, number, or UUID (resolved within the team).
         #[arg(long)]
         cycle: Option<String>,
+        /// Remove the issue from its cycle.
+        #[arg(long, default_value = "false", conflicts_with = "cycle")]
+        clear_cycle: bool,
     },
 }
 
@@ -818,19 +836,25 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
             label_by,
             clear_labels,
             assignee,
+            clear_assignee,
             project,
+            clear_project,
             cycle,
+            clear_cycle,
         } => {
             if status.is_none()
                 && priority.is_none()
                 && labels.is_none()
                 && !clear_labels
                 && assignee.is_none()
+                && !clear_assignee
                 && project.is_none()
+                && !clear_project
                 && cycle.is_none()
+                && !clear_cycle
             {
                 return Err(anyhow::anyhow!(
-                    "No update fields provided. Use --status, --priority, --assignee, --labels, --project, or --cycle to specify changes."
+                    "No update fields provided. Use --status, --priority, --assignee, --labels, --project, --cycle, or a --clear-* flag to specify changes."
                 ));
             }
 
@@ -895,14 +919,14 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
             };
 
             let input = IssueUpdateInput {
-                assignee_id: assignee_id.into(),
+                assignee_id: clear_or_set(clear_assignee, assignee_id),
                 priority: priority.into(),
                 state_id: state_id.into(),
                 label_ids: label_ids.into(),
                 added_label_ids: added_label_ids.into(),
                 removed_label_ids: removed_label_ids.into(),
-                project_id: project_id.into(),
-                cycle_id: cycle_id.into(),
+                project_id: clear_or_set(clear_project, project_id),
+                cycle_id: clear_or_set(clear_cycle, cycle_id),
                 ..Default::default()
             };
 
@@ -923,12 +947,15 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
             label_by,
             clear_labels,
             assignee,
+            clear_assignee,
             parent,
             clear_parent,
             title,
             description,
             project,
+            clear_project,
             cycle,
+            clear_cycle,
         } => {
             if status.is_none()
                 && priority.is_none()
@@ -936,15 +963,18 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
                 && labels.is_none()
                 && !clear_labels
                 && assignee.is_none()
+                && !clear_assignee
                 && parent.is_none()
                 && !clear_parent
                 && title.is_none()
                 && description.is_none()
                 && project.is_none()
+                && !clear_project
                 && cycle.is_none()
+                && !clear_cycle
             {
                 return Err(anyhow::anyhow!(
-                    "No update fields provided. Use --status, --priority, --estimate, --assignee, --labels, --title, --description, --parent, --project, or --cycle to specify changes."
+                    "No update fields provided. Use --status, --priority, --estimate, --assignee, --labels, --title, --description, --parent, --project, --cycle, or a --clear-* flag to specify changes."
                 ));
             }
 
@@ -1011,25 +1041,19 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
                 (None, None, None)
             };
 
-            let parent_id = if clear_parent {
-                MaybeUndefined::Null
-            } else {
-                parent_id.into()
-            };
-
             let input = IssueUpdateInput {
                 title: title.into(),
                 description: description.into(),
-                assignee_id: assignee_id.into(),
+                assignee_id: clear_or_set(clear_assignee, assignee_id),
                 priority: priority.into(),
                 estimate: estimate.into(),
                 state_id: state_id.into(),
-                parent_id,
+                parent_id: clear_or_set(clear_parent, parent_id),
                 label_ids: label_ids.into(),
                 added_label_ids: added_label_ids.into(),
                 removed_label_ids: removed_label_ids.into(),
-                project_id: project_id.into(),
-                cycle_id: cycle_id.into(),
+                project_id: clear_or_set(clear_project, project_id),
+                cycle_id: clear_or_set(clear_cycle, cycle_id),
                 ..Default::default()
             };
 
@@ -1042,6 +1066,15 @@ pub async fn run(cmd: IssuesCmd, client: &Client, format: Format) -> anyhow::Res
         }
     }
     Ok(())
+}
+
+/// Explicit null when clearing, the resolved ID when set, undefined otherwise.
+fn clear_or_set(clear: bool, id: Option<String>) -> MaybeUndefined<String> {
+    if clear {
+        MaybeUndefined::Null
+    } else {
+        id.into()
+    }
 }
 
 // TODO(phase2): query workflowStates types instead of hardcoding state names

--- a/crates/lineark/src/commands/usage.rs
+++ b/crates/lineark/src/commands/usage.rs
@@ -74,6 +74,7 @@ COMMANDS:
   lineark projects read <NAME-OR-ID>               Full project detail (lead, members, status, dates, teams)
   lineark projects create <NAME> --team KEY ...    Create project (--help for flags)
   lineark projects update <NAME-OR-ID> ...         Update project (--help for flags)
+    [--status NAME]                                No archive cmd: retire via --status "Completed"/"Canceled"
   lineark labels list [--team KEY]                 List labels (group, team, parent, color)
   lineark labels create|update|delete ...          Manage labels (--help for flags)
   lineark cycles list [-l N] [--team KEY]          List cycles
@@ -94,11 +95,12 @@ COMMANDS:
     [--cycle NAME-OR-ID]
   lineark issues update <IDENTIFIER>               Update an issue
     [-s NAME] [-p PRIORITY] [-e N]                 Status, priority, estimate
-    [--assignee NAME-OR-ID|me]                     Assignee
+    [--assignee NAME-OR-ID|me] [--clear-assignee]  Assign or unassign
     [--labels NAME,...] [--label-by adding|replacing|removing]
     [--clear-labels] [-t TEXT] [-d TEXT]           Title, description
     [--parent ID] [--clear-parent]                 Set or remove parent
-    [--project NAME-OR-ID] [--cycle NAME-OR-ID]    Project, cycle
+    [--project NAME-OR-ID] [--clear-project]       Set or remove project
+    [--cycle NAME-OR-ID] [--clear-cycle]           Set or remove cycle
   lineark issues batch-update ID [ID ...]          Batch update (--help for flags)
   lineark issues archive|unarchive|delete ...      Lifecycle ops (--help for flags)
   lineark comments create <ISSUE-ID> --body TEXT   Comment on an issue

--- a/crates/lineark/tests/offline.rs
+++ b/crates/lineark/tests/offline.rs
@@ -715,6 +715,40 @@ fn issues_update_help_shows_clear_parent_and_project() {
 }
 
 #[test]
+fn issues_update_help_shows_clear_relation_flags() {
+    lineark()
+        .args(["issues", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--clear-project"))
+        .stdout(predicate::str::contains("--clear-cycle"))
+        .stdout(predicate::str::contains("--clear-assignee"));
+}
+
+#[test]
+fn issues_batch_update_help_shows_clear_relation_flags() {
+    lineark()
+        .args(["issues", "batch-update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--clear-project"))
+        .stdout(predicate::str::contains("--clear-cycle"))
+        .stdout(predicate::str::contains("--clear-assignee"));
+}
+
+#[test]
+fn usage_mentions_projects_status_and_clear_flags() {
+    lineark()
+        .arg("usage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--status"))
+        .stdout(predicate::str::contains("--clear-project"))
+        .stdout(predicate::str::contains("--clear-cycle"))
+        .stdout(predicate::str::contains("--clear-assignee"));
+}
+
+#[test]
 fn issues_search_help_shows_filter_flags() {
     lineark()
         .args(["issues", "search", "--help"])
@@ -741,6 +775,54 @@ fn issues_update_clear_parent_conflicts_with_parent() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn issues_update_clear_flags_conflict_with_setters() {
+    for (setter, value, clearer) in [
+        ("--project", "Alpha", "--clear-project"),
+        ("--cycle", "3", "--clear-cycle"),
+        ("--assignee", "me", "--clear-assignee"),
+    ] {
+        lineark()
+            .args([
+                "--api-token",
+                "fake",
+                "issues",
+                "update",
+                "ENG-123",
+                setter,
+                value,
+                clearer,
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
+
+#[test]
+fn issues_batch_update_clear_flags_conflict_with_setters() {
+    for (setter, value, clearer) in [
+        ("--project", "Alpha", "--clear-project"),
+        ("--cycle", "3", "--clear-cycle"),
+        ("--assignee", "me", "--clear-assignee"),
+    ] {
+        lineark()
+            .args([
+                "--api-token",
+                "fake",
+                "issues",
+                "batch-update",
+                "ENG-123",
+                setter,
+                value,
+                clearer,
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
 }
 
 // ── Documents: filter flags ────────────────────────────────────────────────

--- a/crates/lineark/tests/online.rs
+++ b/crates/lineark/tests/online.rs
@@ -2294,6 +2294,267 @@ mod online {
         delete_issue(&parent_id);
     }
 
+    // ── Issues update: --clear-project / --clear-cycle / --clear-assignee ───
+
+    #[test_with::runtime_ignore_if(no_online_test_token)]
+    fn issues_update_clears_project_cycle_assignee() {
+        let token = test_token();
+        let suffix = &uuid::Uuid::new_v4().to_string()[..8];
+
+        let team = create_test_team();
+        let team_id = team.id.clone();
+        let team_key = team.key.clone();
+
+        // Enable cycles — Linear auto-creates upcoming cycles server-side.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "teams",
+                "update",
+                &team_key,
+                "--cycles-enabled",
+                "true",
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "teams update --cycles-enabled should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+
+        // Cycle generation is asynchronous — wait until cycle 1 is queryable.
+        retry_with_backoff(8, || {
+            let output = lineark()
+                .args([
+                    "--api-token",
+                    &token,
+                    "--format",
+                    "json",
+                    "cycles",
+                    "list",
+                    "--team",
+                    &team_key,
+                ])
+                .output()
+                .unwrap();
+            if !output.status.success() {
+                return Err("cycles list failed".to_string());
+            }
+            let cycles: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+            match cycles.as_array() {
+                Some(arr) if !arr.is_empty() => Ok(()),
+                _ => Err("no cycles generated yet".to_string()),
+            }
+        })
+        .expect("team should have auto-generated cycles (after retries)");
+
+        // Create a project via the SDK.
+        let client = Client::from_token(test_token()).unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let project: Project = rt.block_on(async {
+            let input = ProjectCreateInput {
+                name: format!("[test] clear-flags project {suffix}"),
+                team_ids: vec![team_id],
+                ..Default::default()
+            };
+            retry_create(|| {
+                let input = input.clone();
+                async { client.project_create::<Project>(None, input).await }
+            })
+            .await
+        });
+        let project_id = project.id.as_ref().unwrap().to_string();
+        let _project_guard = ProjectGuard {
+            token: token.clone(),
+            id: project_id.clone(),
+        };
+
+        // Create an issue with project, cycle, and assignee all set.
+        let (output, _) = run_lineark_with_retry(&[
+            "--api-token",
+            &token,
+            "--format",
+            "json",
+            "issues",
+            "create",
+            &format!("[test] clear-flags issue {suffix}"),
+            "--team",
+            &team_key,
+            "--project",
+            &project_id,
+            "--cycle",
+            "1",
+            "--assignee",
+            "me",
+        ]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues create should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        let issue: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let issue_id = issue["id"].as_str().unwrap().to_string();
+        let _issue_guard = IssueGuard {
+            token: token.clone(),
+            id: issue_id.clone(),
+        };
+
+        // Sanity check: all three relations are set.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "read",
+                &issue_id,
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let detail: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            detail["project"].is_object(),
+            "issue should have a project before clearing"
+        );
+        assert!(
+            detail["cycle"].is_object(),
+            "issue should have a cycle before clearing"
+        );
+        assert!(
+            detail["assignee"].is_object(),
+            "issue should have an assignee before clearing"
+        );
+
+        // Clear all three in one update.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "update",
+                &issue_id,
+                "--clear-project",
+                "--clear-cycle",
+                "--clear-assignee",
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues update with clear flags should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+
+        // Verify all three relations are gone.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "read",
+                &issue_id,
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let detail: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            detail["project"].is_null(),
+            "project should be null after --clear-project, got: {}",
+            detail["project"]
+        );
+        assert!(
+            detail["cycle"].is_null(),
+            "cycle should be null after --clear-cycle, got: {}",
+            detail["cycle"]
+        );
+        assert!(
+            detail["assignee"].is_null(),
+            "assignee should be null after --clear-assignee, got: {}",
+            detail["assignee"]
+        );
+
+        // Re-set project and assignee, then clear via batch-update.
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "update",
+                &issue_id,
+                "--project",
+                &project_id,
+                "--assignee",
+                "me",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "re-setting project/assignee should succeed"
+        );
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "batch-update",
+                &issue_id,
+                "--clear-project",
+                "--clear-assignee",
+            ])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "issues batch-update with clear flags should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+
+        let output = lineark()
+            .args([
+                "--api-token",
+                &token,
+                "--format",
+                "json",
+                "issues",
+                "read",
+                &issue_id,
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let detail: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            detail["project"].is_null(),
+            "project should be null after batch-update --clear-project"
+        );
+        assert!(
+            detail["assignee"].is_null(),
+            "assignee should be null after batch-update --clear-assignee"
+        );
+
+        // Clean up.
+        delete_issue(&issue_id);
+    }
+
     // ── Project milestones CRUD ──────────────────────────────────────────────
 
     #[test_with::runtime_ignore_if(no_online_test_token)]


### PR DESCRIPTION
Closes #151.

## Summary

**1. Clearers for optional relations on `issues update` / `issues batch-update`**

`--clear-labels` and `--clear-parent` existed; `--project`, `--cycle`, and `--assignee` had setters but no clearers, so there was no CLI path to unset them (the obvious sentinels like `--project ""` fall into name resolution and fail). Added, following the existing `--clear-*` convention:

| Flag | New clearer | `update` | `batch-update` |
|---|---|---|---|
| `--project` | `--clear-project` | ✅ | ✅ |
| `--cycle` | `--clear-cycle` | ✅ | ✅ |
| `--assignee` | `--clear-assignee` | ✅ | ✅ |

Each clearer `conflicts_with` its setter and maps to an explicit `null` in `IssueUpdateInput` (`MaybeUndefined::Null`), same mechanism as `--clear-parent`. A lone `--clear-*` flag now also counts as "an update field was provided". `--clear-parent` was refactored onto the same small helper (`clear_or_set`).

**2. Project retirement discoverability**

There is no archive command to add — `projectArchive` doesn't exist in Linear's API and `projectDelete` really deletes (per the issue's schema check, kept out of scope). The intended path is `projects update --status "Completed"/"Canceled"`, which existed but was invisible:

- `lineark usage` now shows `[--status NAME]` under `projects update` with an explicit "No archive cmd: retire via --status" note.
- CLI README now lists `projects update` (it was missing entirely) with the same note, plus the new `--clear-*` flags.

## Test plan

- [x] `make check` — clippy, doc, build all clean
- [x] `make test` — 131 offline CLI tests pass, including new ones:
  - help output shows the three new flags on both `update` and `batch-update`
  - each clearer conflicts with its setter (both subcommands)
  - `usage` mentions `--status` and the clear flags
- [x] New online test `issues_update_clears_project_cycle_assignee` **passed against the live Linear API**: creates a team (enables cycles via `teams update --cycles-enabled true`, waits for Linear's async cycle generation with `retry_with_backoff`), creates a project and an issue with project + cycle + assignee set, clears all three in one `issues update`, verifies all null via `issues read`, then re-sets project/assignee and clears them again via `batch-update`. Follows the three pillars (guards, unique `[test]` names, per-call retries).
- [ ] CI (including the full online suite on this same-repo PR)

Next release: minor bump (new flags, no breaking changes).